### PR TITLE
Implement websocket install helper

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,7 +6,7 @@ formatting.
 
 1. **Foundation and API Setup** (lines 140-170)
 
-   - [ ] Implement `falcon_ws.install(app)` to attach a
+   - [x] Implement `falcon_ws.install(app)` to attach a
      `WebSocketConnectionManager` to the Falcon `App`.
    - [ ] Provide `app.add_websocket_route()` mirroring Falcon’s HTTP routing.
 
@@ -21,11 +21,9 @@ formatting.
 3. **Connection Manager** (lines 288-340)
 
    - [ ] Implement `WebSocketConnectionManager` with methods for managing
-     connections and rooms: `add_connection`, `remove_connection`, `join_room`,
-     `leave_room`, `broadcast_to_room`, `send_to_connection`,
-     `get_connections_in_room`, and `get_rooms_by_prefix`.
-   - [ ] Provide helper methods in `WebSocketResource` for common room
-     operations.
+     connections: `add_connection`, `remove_connection`, `send_to_connection`.
+   - [ ] Connection grouping and pub/sub integration will be handled
+     externally.
 
 4. **Background Worker Integration** (lines 342-375)
 

--- a/falcon_ws/__init__.py
+++ b/falcon_ws/__init__.py
@@ -1,0 +1,26 @@
+"""Falcon-AsyncWS extension package."""
+
+from __future__ import annotations
+
+import falcon.asgi
+
+from .connection_manager import WebSocketConnectionManager
+
+_MANAGERS: dict[int, WebSocketConnectionManager] = {}
+
+
+def _get_ws_manager(app: falcon.asgi.App) -> WebSocketConnectionManager:
+    return _MANAGERS[id(app)]
+
+
+if not hasattr(falcon.asgi.App, "ws_connection_manager"):
+    falcon.asgi.App.ws_connection_manager = property(_get_ws_manager)  # type: ignore[attr-defined]
+
+__all__ = ["WebSocketConnectionManager", "install"]
+
+
+def install(app: falcon.asgi.App) -> None:
+    """Attach a :class:`WebSocketConnectionManager` to ``app``."""
+    if id(app) in _MANAGERS:
+        raise RuntimeError("WebSocketConnectionManager already installed")
+    _MANAGERS[id(app)] = WebSocketConnectionManager()

--- a/falcon_ws/connection_manager.py
+++ b/falcon_ws/connection_manager.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import typing as t
+
+import falcon.asgi
+
+
+@dataclass(slots=True)
+class WebSocketConnectionManager:
+    """Generic manager for WebSocket connections.
+
+    The base implementation only tracks connections and lets subclasses
+    implement additional features such as pub/sub integration. This mirrors how
+    Falcon resources are extended for HTTP routing.
+    """
+
+    _connections: dict[str, falcon.asgi.WebSocket] = field(
+        default_factory=dict[str, falcon.asgi.WebSocket]
+    )
+
+    async def add_connection(
+        self, connection_id: str, websocket: falcon.asgi.WebSocket
+    ) -> None:
+        """Register a new connection."""
+        self._connections[connection_id] = websocket
+
+    async def remove_connection(self, connection_id: str) -> None:
+        """Remove a connection."""
+        self._connections.pop(connection_id, None)
+
+    async def send_to_connection(self, connection_id: str, message: t.Any) -> None:
+        """Send a message to a specific connection."""
+        websocket = self._connections.get(connection_id)
+        if websocket is not None:
+            await websocket.send_text(
+                message if isinstance(message, str) else json.dumps(message)
+            )

--- a/falcon_ws/unittests/test_install.py
+++ b/falcon_ws/unittests/test_install.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import falcon.asgi
+
+import falcon_ws
+import pytest
+
+
+def test_install_attaches_connection_manager() -> None:
+    app = falcon.asgi.App()
+    falcon_ws.install(app)
+    manager = getattr(app, "ws_connection_manager")
+    assert isinstance(manager, falcon_ws.WebSocketConnectionManager)
+
+
+def test_install_fails_when_already_installed() -> None:
+    app = falcon.asgi.App()
+    falcon_ws.install(app)
+    with pytest.raises(RuntimeError):
+        falcon_ws.install(app)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ dev = ["pytest", "ruff", "pyright"]
 
 [tool.pyright]
 pythonVersion = "3.13"
-strict = true
-include = ["falcon_pachinko"]
+typeCheckingMode = "strict"
+include = ["falcon_pachinko", "falcon_ws"]
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
## Summary
- implement `falcon_ws.install` that attaches a connection manager to a Falcon app
- create minimal `WebSocketConnectionManager`
- include unit test for `falcon_ws.install`
- configure pyright to check both packages
- mark roadmap item as complete
- clarify that `WebSocketConnectionManager` is generic
- add unit test covering duplicate install
- remove room management from connection manager and docs

## Testing
- `ruff check falcon_ws/connection_manager.py falcon_ws/__init__.py falcon_ws/unittests/test_install.py`
- `pyright` *(fails: Import "falcon.asgi" could not be resolved)*
- `PYTHONPATH=$(pwd) pytest -q` *(fails: ModuleNotFoundError: No module named 'falcon')*

------
https://chatgpt.com/codex/tasks/task_e_68498bb20e7083229314b855d7530f40