### PR TITLE
Remove obsolete pure helper

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+docstrings:
+  style: numpy

--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ formatting.
 
    - [x] Implement `falcon_pachinko.install(app)` to attach a
      `WebSocketConnectionManager` to the Falcon `App`.
-   - [ ] Provide `app.add_websocket_route()` mirroring Falcon’s HTTP routing.
+   - [x] Provide `app.add_websocket_route()` mirroring Falcon’s HTTP routing.
 
 2. **WebSocketResource Base Class** (lines 207-247)
 

--- a/falcon_pachinko/__init__.py
+++ b/falcon_pachinko/__init__.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-PACKAGE_NAME = "falcon_pachinko"
+from .websocket import WebSocketConnectionManager, install
 
-try:  # pragma: no cover - Rust optional
-    rust = __import__(f"_{PACKAGE_NAME}_rs")
-    hello = rust.hello  # type: ignore[attr-defined]
-except ModuleNotFoundError:  # pragma: no cover - Python fallback
-    from .pure import hello
 
-__all__ = ["hello"]
+def hello() -> str:
+    """Return a friendly greeting."""
+    return "hello from Python"
+
+
+__all__ = ["hello", "install", "WebSocketConnectionManager"]

--- a/falcon_pachinko/__init__.py
+++ b/falcon_pachinko/__init__.py
@@ -5,9 +5,4 @@ from __future__ import annotations
 from .websocket import WebSocketConnectionManager, install
 
 
-def hello() -> str:
-    """Return a friendly greeting."""
-    return "hello from Python"
-
-
-__all__ = ["hello", "install", "WebSocketConnectionManager"]
+__all__ = ["install", "WebSocketConnectionManager"]

--- a/falcon_pachinko/pure.py
+++ b/falcon_pachinko/pure.py
@@ -1,6 +1,0 @@
-from __future__ import annotations
-
-
-def hello() -> str:
-    """Return a friendly greeting from Python."""
-    return "hello from Python"

--- a/falcon_pachinko/unittests/test_app_install.py
+++ b/falcon_pachinko/unittests/test_app_install.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import pytest
+
 from falcon_pachinko import install
+from falcon_pachinko.websocket import WebSocketConnectionManager
 
 
 class DummyApp:
@@ -15,7 +18,7 @@ def test_install_adds_methods_and_manager() -> None:
     app_any = cast(Any, app)
 
     assert hasattr(app_any, "ws_connection_manager")
-    assert isinstance(app_any.ws_connection_manager, object)
+    assert isinstance(app_any.ws_connection_manager, WebSocketConnectionManager)
     assert callable(app_any.add_websocket_route)
 
 
@@ -28,3 +31,25 @@ def test_add_websocket_route_registers_resource() -> None:
     app_any.add_websocket_route("/ws", resource)
 
     assert app_any._websocket_routes["/ws"] is resource
+
+
+def test_install_is_idempotent() -> None:
+    app = DummyApp()
+    install(app)  # type: ignore[arg-type]
+    app_any = cast(Any, app)
+    first_manager = app_any.ws_connection_manager
+
+    install(app)  # type: ignore[arg-type]
+    assert app_any.ws_connection_manager is first_manager
+
+
+def test_add_websocket_route_duplicate_raises() -> None:
+    app = DummyApp()
+    install(app)  # type: ignore[arg-type]
+    app_any = cast(Any, app)
+
+    resource = object()
+    app_any.add_websocket_route("/ws", resource)
+
+    with pytest.raises(ValueError):
+        app_any.add_websocket_route("/ws", resource)

--- a/falcon_pachinko/unittests/test_app_install.py
+++ b/falcon_pachinko/unittests/test_app_install.py
@@ -17,6 +17,16 @@ class SupportsWebSocket(Protocol):
     _websocket_routes: dict[str, object]
 
     def add_websocket_route(self, path: str, resource: object) -> None:
+        """
+        Registers a WebSocket resource to handle connections at the specified path.
+        
+        Args:
+            path: The URL path for the WebSocket route.
+            resource: The resource object that will handle WebSocket connections for the given path.
+        
+        Raises:
+            ValueError: If a resource is already registered for the specified path.
+        """
         ...
 
 
@@ -42,6 +52,11 @@ def test_add_websocket_route_registers_resource() -> None:
 
 
 def test_install_is_idempotent() -> None:
+    """
+    Tests that calling install multiple times does not alter existing WebSocket support on the app.
+    
+    Verifies that repeated installation leaves the connection manager and route registration method unchanged, ensuring idempotency.
+    """
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
     app_any = cast(SupportsWebSocket, app)
@@ -54,6 +69,11 @@ def test_install_is_idempotent() -> None:
 
 
 def test_install_detects_partial_state() -> None:
+    """
+    Tests that `install` raises a RuntimeError if called on an app missing internal WebSocket state.
+    
+    Simulates a partially installed or tampered app by deleting the `_websocket_routes` attribute after installation, then verifies that a subsequent call to `install` detects the inconsistency and raises a RuntimeError.
+    """
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
     app_any = cast(SupportsWebSocket, app)

--- a/falcon_pachinko/unittests/test_app_install.py
+++ b/falcon_pachinko/unittests/test_app_install.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from falcon_pachinko import install
+
+
+class DummyApp:
+    pass
+
+
+def test_install_adds_methods_and_manager() -> None:
+    app = DummyApp()
+    install(app)  # type: ignore[arg-type]
+    app_any = cast(Any, app)
+
+    assert hasattr(app_any, "ws_connection_manager")
+    assert isinstance(app_any.ws_connection_manager, object)
+    assert callable(app_any.add_websocket_route)
+
+
+def test_add_websocket_route_registers_resource() -> None:
+    app = DummyApp()
+    install(app)  # type: ignore[arg-type]
+    app_any = cast(Any, app)
+
+    resource = object()
+    app_any.add_websocket_route("/ws", resource)
+
+    assert app_any._websocket_routes["/ws"] is resource

--- a/falcon_pachinko/unittests/test_app_install.py
+++ b/falcon_pachinko/unittests/test_app_install.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Protocol, cast
 
 import pytest
 
@@ -12,10 +12,18 @@ class DummyApp:
     pass
 
 
+class SupportsWebSocket(Protocol):
+    ws_connection_manager: WebSocketConnectionManager
+    _websocket_routes: dict[str, object]
+
+    def add_websocket_route(self, path: str, resource: object) -> None:
+        ...
+
+
 def test_install_adds_methods_and_manager() -> None:
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
-    app_any = cast(Any, app)
+    app_any = cast(SupportsWebSocket, app)
 
     assert hasattr(app_any, "ws_connection_manager")
     assert isinstance(app_any.ws_connection_manager, WebSocketConnectionManager)
@@ -25,28 +33,30 @@ def test_install_adds_methods_and_manager() -> None:
 def test_add_websocket_route_registers_resource() -> None:
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
-    app_any = cast(Any, app)
+    app_any = cast(SupportsWebSocket, app)
 
     resource = object()
     app_any.add_websocket_route("/ws", resource)
 
-    assert app_any._websocket_routes["/ws"] is resource
+    assert app_any._websocket_routes["/ws"] is resource  # pyright: ignore[reportPrivateUsage]
 
 
 def test_install_is_idempotent() -> None:
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
-    app_any = cast(Any, app)
+    app_any = cast(SupportsWebSocket, app)
     first_manager = app_any.ws_connection_manager
+    first_route_fn = app_any.add_websocket_route
 
     install(app)  # type: ignore[arg-type]
     assert app_any.ws_connection_manager is first_manager
+    assert app_any.add_websocket_route is first_route_fn
 
 
 def test_install_detects_partial_state() -> None:
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
-    app_any = cast(Any, app)
+    app_any = cast(SupportsWebSocket, app)
 
     # Simulate tampering with one of the install attributes
     delattr(app_any, "_websocket_routes")
@@ -58,7 +68,7 @@ def test_install_detects_partial_state() -> None:
 def test_add_websocket_route_duplicate_raises() -> None:
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
-    app_any = cast(Any, app)
+    app_any = cast(SupportsWebSocket, app)
 
     resource = object()
     app_any.add_websocket_route("/ws", resource)

--- a/falcon_pachinko/unittests/test_app_install.py
+++ b/falcon_pachinko/unittests/test_app_install.py
@@ -43,6 +43,18 @@ def test_install_is_idempotent() -> None:
     assert app_any.ws_connection_manager is first_manager
 
 
+def test_install_detects_partial_state() -> None:
+    app = DummyApp()
+    install(app)  # type: ignore[arg-type]
+    app_any = cast(Any, app)
+
+    # Simulate tampering with one of the install attributes
+    delattr(app_any, "_websocket_routes")
+
+    with pytest.raises(RuntimeError):
+        install(app)  # type: ignore[arg-type]
+
+
 def test_add_websocket_route_duplicate_raises() -> None:
     app = DummyApp()
     install(app)  # type: ignore[arg-type]

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -9,6 +9,11 @@ class WebSocketConnectionManager:
     """Track active WebSocket connections."""
 
     def __init__(self) -> None:
+        """
+        Initialises the WebSocketConnectionManager with empty connection and room mappings.
+        
+        Creates dictionaries to track active WebSocket connections and group them into rooms.
+        """
         self.connections: dict[str, Any] = {}
         self.rooms: dict[str, set[str]] = {}
 
@@ -17,7 +22,11 @@ class WebSocketConnectionManager:
 
 
 def install(app: Any) -> None:
-    """Attach WebSocket utilities to a Falcon app."""
+    """
+    Attaches WebSocket management utilities to a Falcon app instance.
+    
+    Initialises and binds a WebSocket connection manager, a route mapping dictionary, and a method for registering WebSocket routes to the app. If the app already has all required WebSocket attributes, the function does nothing. If only some attributes are present, raises a RuntimeError to prevent inconsistent state.
+    """
     wanted = (
         "ws_connection_manager",
         "_websocket_routes",
@@ -43,10 +52,10 @@ _route_lock = Lock()
 
 
 def _add_websocket_route(self: Any, path: str, resource: Any) -> None:
-    """Register a WebSocket resource for the given path.
-
-    This function is safe to call from multiple threads, but it should usually
-    be invoked during application start-up.
+    """
+    Registers a WebSocket resource handler for a specified path on the application.
+    
+    Ensures thread-safe registration and raises a ValueError if the path is already registered.
     """
     with _route_lock:
         if path in self._websocket_routes:

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -17,6 +17,10 @@ class WebSocketConnectionManager:
 
 def install(app: Any) -> None:
     """Attach WebSocket utilities to a Falcon app."""
+    if hasattr(app, "ws_connection_manager"):
+        # Already installed – do nothing.
+        return
+
     app.ws_connection_manager = WebSocketConnectionManager()
     app._websocket_routes = {}
     app.add_websocket_route = MethodType(_add_websocket_route, app)
@@ -24,4 +28,8 @@ def install(app: Any) -> None:
 
 def _add_websocket_route(self: Any, path: str, resource: Any) -> None:
     """Register a WebSocket resource for the given path."""
+    if path in self._websocket_routes:
+        msg = f"WebSocket route already registered for path: {path}"
+        raise ValueError(msg)
+
     self._websocket_routes[path] = resource

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from threading import Lock
 from types import MethodType
-from typing import Any, cast
+from typing import Any
 
 
 class WebSocketConnectionManager:
@@ -33,14 +34,23 @@ def install(app: Any) -> None:
         raise RuntimeError("Partial WebSocket install detected; aborting.")
 
     app.ws_connection_manager = WebSocketConnectionManager()
-    app._websocket_routes = cast(dict[str, Any], {})
+    routes: dict[str, Any] = {}
+    app._websocket_routes = routes
     app.add_websocket_route = MethodType(_add_websocket_route, app)
 
 
-def _add_websocket_route(self: Any, path: str, resource: Any) -> None:
-    """Register a WebSocket resource for the given path."""
-    if path in self._websocket_routes:
-        msg = f"WebSocket route already registered for path: {path}"
-        raise ValueError(msg)
+_route_lock = Lock()
 
-    self._websocket_routes[path] = resource
+
+def _add_websocket_route(self: Any, path: str, resource: Any) -> None:
+    """Register a WebSocket resource for the given path.
+
+    This function is safe to call from multiple threads, but it should usually
+    be invoked during application start-up.
+    """
+    with _route_lock:
+        if path in self._websocket_routes:
+            msg = f"WebSocket route already registered for path: {path}"
+            raise ValueError(msg)
+
+        self._websocket_routes[path] = resource

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from types import MethodType
+from typing import Any
+
+
+class WebSocketConnectionManager:
+    """Track active WebSocket connections."""
+
+    def __init__(self) -> None:
+        self.connections: dict[str, Any] = {}
+        self.rooms: dict[str, set[str]] = {}
+
+
+# Public API ---------------------------------------------------------------
+
+
+def install(app: Any) -> None:
+    """Attach WebSocket utilities to a Falcon app."""
+    app.ws_connection_manager = WebSocketConnectionManager()
+    app._websocket_routes = {}
+    app.add_websocket_route = MethodType(_add_websocket_route, app)
+
+
+def _add_websocket_route(self: Any, path: str, resource: Any) -> None:
+    """Register a WebSocket resource for the given path."""
+    self._websocket_routes[path] = resource

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dev = ["pytest", "ruff", "pyright"]
 
 [tool.pyright]
 pythonVersion = "3.13"
-strict = true
+typeCheckingMode = "strict"
 include = ["falcon_pachinko"]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- drop `pure.py`
- define `hello()` directly in `__init__`

## Testing
- `ruff check falcon_pachinko/websocket.py falcon_pachinko/__init__.py falcon_pachinko/unittests/test_app_install.py`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a0a76cde48322a3b68aa67bda0dc6

## Summary by Sourcery

Remove the obsolete pure helper and consolidate package initialization, extract WebSocket support into a dedicated module with install APIs, update exports, add unit tests, revise documentation, and tighten type checking configuration.

New Features:
- Introduce `WebSocketConnectionManager` and `install()` to integrate WebSocket support into Falcon apps
- Provide `app.add_websocket_route()` for registering WebSocket routes

Enhancements:
- Remove `pure.py` and inline `hello()` implementation in package initialization

Build:
- Update Pyright configuration to use strict `typeCheckingMode`

Documentation:
- Update roadmap to mark WebSocket routing feature as completed

Tests:
- Add unit tests for `install()` and `add_websocket_route()` functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced WebSocket connection management and routing utilities for Falcon applications, allowing registration and management of WebSocket routes.
  - Added a simple greeting function accessible at the package level.
- **Bug Fixes**
  - None.
- **Tests**
  - Added unit tests to verify installation and route registration of WebSocket functionality.
- **Documentation**
  - Updated roadmap to mark WebSocket route support as complete.
- **Chores**
  - Adjusted type checking configuration for improved static analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->