### PR TITLE
Add typed WebSocketResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ for the full design rationale.
   classes, mirroring Falcon's HTTP routing.
 - `WebSocketResource` provides `on_connect`, `on_disconnect`, and
   `on_message` lifecycle hooks.
+- Message payloads are parsed into `msgspec.Struct` classes for speed and type
+  safety.
 - `@handles_message("type")` dispatches incoming JSON messages to specific
   handler methods.
 - `WebSocketConnectionManager` tracks connections, manages rooms, and lets

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -280,9 +280,12 @@ a monolithic `on_receive` method with extensive conditional logic.
   distinct HTTP methods and paths organize REST API interactions.
 
 - **Automatic Deserialization**: For messages routed via `@handles_message`, the
-  library will attempt to parse the message as JSON and extract the payload. If
-  parsing fails or the 'type' field is missing, the generic `on_message` handler
-  could be invoked if defined.
+    library will attempt to parse the message as JSON and extract the payload. If
+    parsing fails or the 'type' field is missing, the generic `on_message` handler
+    could be invoked if defined.
+
+- **Typed Payloads**: Message payloads are decoded using `msgspec.Struct` classes
+  for type safety and fast serialization.
 
 ### 3.7. `WebSocketConnectionManager`
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@ formatting.
 
 2. **WebSocketResource Base Class** (lines 207-247)
 
-   - [ ] Create `WebSocketResource` with `on_connect`, `on_disconnect`, and
+   - [x] Create `WebSocketResource` with `on_connect`, `on_disconnect`, and
      `on_message` lifecycle methods.
    - [ ] Include connection-specific state (one instance per connection).
    - [ ] Add decorator `@handles_message("type")` for dispatching JSON messages

--- a/falcon_pachinko/__init__.py
+++ b/falcon_pachinko/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
+from .resource import WebSocketResource
 from .websocket import WebSocketConnectionManager, install
 
-
-__all__ = ["install", "WebSocketConnectionManager"]
+__all__ = ["WebSocketConnectionManager", "WebSocketResource", "install"]

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -17,9 +17,10 @@ Handler = cabc.Callable[[typing.Any, typing.Any, typing.Any], cabc.Awaitable[Non
 class WebSocketResource:
     """Base class for WebSocket handlers."""
 
-    handlers: dict[str, tuple[Handler, type | None]]
+    handlers: typing.ClassVar[dict[str, tuple[Handler, type | None]]]
 
-    def __init_subclass__(cls) -> None:
+    def __init_subclass__(cls, **kwargs: typing.Any) -> None:
+        super().__init_subclass__(**kwargs)
         cls.handlers = {}
 
     async def on_connect(
@@ -59,9 +60,10 @@ class WebSocketResource:
         if payload_type is not None and payload is not None:
             try:
                 payload = typing.cast(
-                    typing.Any, msgspec.convert(payload, type=payload_type)
+                    "typing.Any",
+                    msgspec.convert(payload, type=payload_type),
                 )
-            except Exception:  # noqa: BLE001
+            except (msgspec.ValidationError, TypeError):
                 await self.on_message(ws, raw)
                 return
         await handler(self, ws, payload)

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import collections.abc as cabc
+import typing
+
+import msgspec
+
+
+class _Envelope(msgspec.Struct, frozen=True):
+    type: str
+    payload: typing.Any | None = None
+
+
+Handler = cabc.Callable[[typing.Any, typing.Any, typing.Any], cabc.Awaitable[None]]
+
+
+class WebSocketResource:
+    """Base class for WebSocket handlers."""
+
+    handlers: dict[str, tuple[Handler, type | None]]
+
+    def __init_subclass__(cls) -> None:
+        cls.handlers = {}
+
+    async def on_connect(
+        self, req: typing.Any, ws: typing.Any, **params: typing.Any
+    ) -> bool:
+        """Called when the WebSocket handshake is complete."""
+        return True
+
+    async def on_disconnect(self, ws: typing.Any, close_code: int) -> None:
+        """Called when the WebSocket disconnects."""
+
+    async def on_message(self, ws: typing.Any, message: str | bytes) -> None:
+        """Fallback for unhandled messages."""
+
+    @classmethod
+    def add_handler(
+        cls, message_type: str, handler: Handler, *, payload_type: type | None = None
+    ) -> None:
+        """Register ``handler`` for ``message_type``."""
+        cls.handlers[message_type] = (handler, payload_type)
+
+    async def dispatch(self, ws: typing.Any, raw: str | bytes) -> None:
+        """Dispatch a raw WebSocket message to a handler."""
+        try:
+            envelope = msgspec.json.decode(raw, type=_Envelope)
+        except msgspec.DecodeError:
+            await self.on_message(ws, raw)
+            return
+
+        entry = self.__class__.handlers.get(envelope.type)
+        if not entry:
+            await self.on_message(ws, raw)
+            return
+
+        handler, payload_type = entry
+        payload: typing.Any = envelope.payload
+        if payload_type is not None and payload is not None:
+            try:
+                payload = typing.cast(
+                    typing.Any, msgspec.convert(payload, type=payload_type)
+                )
+            except Exception:  # noqa: BLE001
+                await self.on_message(ws, raw)
+                return
+        await handler(self, ws, payload)

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -20,30 +20,63 @@ class WebSocketResource:
     handlers: typing.ClassVar[dict[str, tuple[Handler, type | None]]]
 
     def __init_subclass__(cls, **kwargs: typing.Any) -> None:
+        """
+        Initializes the handlers dictionary for each subclass of WebSocketResource.
+        
+        Ensures that each subclass has its own independent mapping of message types to handler functions.
+        """
         super().__init_subclass__(**kwargs)
         cls.handlers = {}
 
     async def on_connect(
         self, req: typing.Any, ws: typing.Any, **params: typing.Any
     ) -> bool:
-        """Called when the WebSocket handshake is complete."""
+        """
+        Called after the WebSocket handshake is complete to determine if the connection should be accepted.
+        
+        Args:
+            req: The incoming HTTP request associated with the WebSocket handshake.
+            ws: The WebSocket connection object.
+            **params: Additional parameters relevant to the connection.
+        
+        Returns:
+            True to accept the WebSocket connection; False to reject it.
+        """
         return True
 
     async def on_disconnect(self, ws: typing.Any, close_code: int) -> None:
-        """Called when the WebSocket disconnects."""
+        """
+        Handles cleanup or custom logic when the WebSocket connection is closed.
+        
+        Args:
+            ws: The WebSocket connection instance.
+            close_code: The close code indicating the reason for disconnection.
+        """
 
     async def on_message(self, ws: typing.Any, message: str | bytes) -> None:
-        """Fallback for unhandled messages."""
+        """
+        Handles incoming WebSocket messages that do not match any registered handler.
+        
+        Called when a message cannot be decoded or its type is unrecognized. Override to implement custom fallback behavior for such messages.
+        """
 
     @classmethod
     def add_handler(
         cls, message_type: str, handler: Handler, *, payload_type: type | None = None
     ) -> None:
-        """Register ``handler`` for ``message_type``."""
+        """
+        Registers a handler function for a specific message type.
+        
+        Associates the given handler with the specified message type. Optionally, a payload type can be provided for automatic payload validation and conversion.
+        """
         cls.handlers[message_type] = (handler, payload_type)
 
     async def dispatch(self, ws: typing.Any, raw: str | bytes) -> None:
-        """Dispatch a raw WebSocket message to a handler."""
+        """
+        Processes an incoming raw WebSocket message and dispatches it to the appropriate handler.
+        
+        Attempts to decode the message as a JSON envelope containing a message type and optional payload. If decoding or payload validation fails, or if no handler is registered for the message type, the message is passed to the fallback `on_message` method. Otherwise, the registered handler is invoked with the converted payload.
+        """
         try:
             envelope = msgspec.json.decode(raw, type=_Envelope)
         except msgspec.DecodeError:

--- a/falcon_pachinko/unittests/test_app_install.py
+++ b/falcon_pachinko/unittests/test_app_install.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Protocol, cast
+import typing
 
 import pytest
 
@@ -12,20 +12,17 @@ class DummyApp:
     pass
 
 
-class SupportsWebSocket(Protocol):
+class SupportsWebSocket(typing.Protocol):
     ws_connection_manager: WebSocketConnectionManager
     _websocket_routes: dict[str, object]
 
     def add_websocket_route(self, path: str, resource: object) -> None:
-        """
-        Registers a WebSocket resource to handle connections at the specified path.
-        
-        Args:
-            path: The URL path for the WebSocket route.
-            resource: The resource object that will handle WebSocket connections for the given path.
-        
-        Raises:
-            ValueError: If a resource is already registered for the specified path.
+        """Register ``resource`` for the given WebSocket ``path``.
+
+        Raises
+        ------
+        ValueError
+            If a resource is already registered for ``path``.
         """
         ...
 
@@ -33,7 +30,7 @@ class SupportsWebSocket(Protocol):
 def test_install_adds_methods_and_manager() -> None:
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
-    app_any = cast(SupportsWebSocket, app)
+    app_any = typing.cast("SupportsWebSocket", app)
 
     assert hasattr(app_any, "ws_connection_manager")
     assert isinstance(app_any.ws_connection_manager, WebSocketConnectionManager)
@@ -43,7 +40,7 @@ def test_install_adds_methods_and_manager() -> None:
 def test_add_websocket_route_registers_resource() -> None:
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
-    app_any = cast(SupportsWebSocket, app)
+    app_any = typing.cast("SupportsWebSocket", app)
 
     resource = object()
     app_any.add_websocket_route("/ws", resource)
@@ -52,14 +49,10 @@ def test_add_websocket_route_registers_resource() -> None:
 
 
 def test_install_is_idempotent() -> None:
-    """
-    Tests that calling install multiple times does not alter existing WebSocket support on the app.
-    
-    Verifies that repeated installation leaves the connection manager and route registration method unchanged, ensuring idempotency.
-    """
+    """Repeated installs leave WebSocket state unchanged."""
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
-    app_any = cast(SupportsWebSocket, app)
+    app_any = typing.cast("SupportsWebSocket", app)
     first_manager = app_any.ws_connection_manager
     first_route_fn = app_any.add_websocket_route
 
@@ -69,14 +62,10 @@ def test_install_is_idempotent() -> None:
 
 
 def test_install_detects_partial_state() -> None:
-    """
-    Tests that `install` raises a RuntimeError if called on an app missing internal WebSocket state.
-    
-    Simulates a partially installed or tampered app by deleting the `_websocket_routes` attribute after installation, then verifies that a subsequent call to `install` detects the inconsistency and raises a RuntimeError.
-    """
+    """install raises RuntimeError when internal state is missing."""
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
-    app_any = cast(SupportsWebSocket, app)
+    app_any = typing.cast("SupportsWebSocket", app)
 
     # Simulate tampering with one of the install attributes
     delattr(app_any, "_websocket_routes")
@@ -88,7 +77,7 @@ def test_install_detects_partial_state() -> None:
 def test_add_websocket_route_duplicate_raises() -> None:
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
-    app_any = cast(SupportsWebSocket, app)
+    app_any = typing.cast("SupportsWebSocket", app)
 
     resource = object()
     app_any.add_websocket_route("/ws", resource)

--- a/falcon_pachinko/unittests/test_app_install.py
+++ b/falcon_pachinko/unittests/test_app_install.py
@@ -17,17 +17,17 @@ class SupportsWebSocket(typing.Protocol):
     _websocket_routes: dict[str, object]
 
     def add_websocket_route(self, path: str, resource: object) -> None:
-        """Register ``resource`` for the given WebSocket ``path``.
-
-        Raises
-        ------
-        ValueError
-            If a resource is already registered for ``path``.
+        """
+        Registers a resource to handle WebSocket connections at the specified path.
+        
+        Raises:
+            ValueError: If a resource is already registered for the given path.
         """
         ...
 
 
 def test_install_adds_methods_and_manager() -> None:
+    """Tests that installing WebSocket support adds the connection manager and route registration method to the app."""
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
     app_any = typing.cast("SupportsWebSocket", app)
@@ -38,6 +38,9 @@ def test_install_adds_methods_and_manager() -> None:
 
 
 def test_add_websocket_route_registers_resource() -> None:
+    """
+    Tests that add_websocket_route registers a resource under the specified WebSocket path.
+    """
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
     app_any = typing.cast("SupportsWebSocket", app)
@@ -49,7 +52,9 @@ def test_add_websocket_route_registers_resource() -> None:
 
 
 def test_install_is_idempotent() -> None:
-    """Repeated installs leave WebSocket state unchanged."""
+    """
+    Tests that installing WebSocket support multiple times does not alter the app's WebSocket state.
+    """
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
     app_any = typing.cast("SupportsWebSocket", app)
@@ -62,7 +67,9 @@ def test_install_is_idempotent() -> None:
 
 
 def test_install_detects_partial_state() -> None:
-    """install raises RuntimeError when internal state is missing."""
+    """
+    Tests that install raises RuntimeError if required internal state is missing from the app.
+    """
     app = DummyApp()
     install(app)  # type: ignore[arg-type]
     app_any = typing.cast("SupportsWebSocket", app)

--- a/falcon_pachinko/unittests/test_websocket_resource.py
+++ b/falcon_pachinko/unittests/test_websocket_resource.py
@@ -18,16 +18,33 @@ class DummyWS:
 
 class EchoResource(WebSocketResource):
     def __init__(self) -> None:
+        """
+        Initializes the EchoResource with empty lists for handled and fallback messages.
+        
+        The `seen` list stores texts from successfully handled payloads, while the `fallback` list records messages that do not match any registered handler or fail payload validation.
+        """
         self.seen: list[typing.Any] = []
         self.fallback: list[typing.Any] = []
 
     async def on_message(self, ws: typing.Any, message: str | bytes) -> None:
+        """
+        Handles messages that do not match any registered handler by appending them to the fallback list.
+        
+        Args:
+            ws: The WebSocket connection instance.
+            message: The raw message received, as a string or bytes.
+        """
         self.fallback.append(message)
 
 
 async def echo_handler(
     self: EchoResource, ws: typing.Any, payload: EchoPayload
 ) -> None:
+    """
+    Handles an "echo" message by recording the payload text.
+    
+    Appends the `text` field from the received `EchoPayload` to the resource's `seen` list.
+    """
     self.seen.append(payload.text)
 
 
@@ -36,13 +53,27 @@ EchoResource.add_handler("echo", echo_handler, payload_type=EchoPayload)
 
 class RawResource(WebSocketResource):
     def __init__(self) -> None:
+        """
+        Initializes the RawResource instance with an empty list to store received messages or payloads.
+        """
         self.received: list[typing.Any] = []
 
     async def on_message(self, ws: typing.Any, message: str | bytes) -> None:
+        """
+        Handles incoming messages by appending them to the received list.
+        
+        This method acts as a fallback for messages that do not match any registered handler.
+        """
         self.received.append(message)
 
 
 async def raw_handler(self: RawResource, ws: typing.Any, payload: typing.Any) -> None:
+    """
+    Handles incoming messages of type "raw" by appending the payload to the resource's received list.
+    
+    Args:
+        payload: The raw payload received with the message. Can be any type, including None.
+    """
     self.received.append(payload)
 
 
@@ -60,6 +91,11 @@ async def test_dispatch_calls_registered_handler() -> None:
 
 @pytest.mark.asyncio()
 async def test_dispatch_unknown_type_calls_fallback() -> None:
+    """
+    Tests that dispatching a message with an unknown type invokes the fallback handler.
+    
+    Verifies that when a message with an unregistered type is dispatched to EchoResource, the raw message is appended to the resource's fallback list.
+    """
     r = EchoResource()
     raw = msgspec.json.encode({"type": "unknown", "payload": {"text": "oops"}})
     await r.dispatch(DummyWS(), raw)
@@ -89,6 +125,11 @@ async def test_handler_shared_across_instances() -> None:
 async def test_payload_type_none_passes_raw(
     payload: typing.Any, expected: typing.Any
 ) -> None:
+    """
+    Tests that RawResource receives the raw payload as-is when no payload type is specified.
+    
+    Verifies that the received list contains the exact payload passed, or None if the payload is missing.
+    """
     r = RawResource()
     msg: dict[str, typing.Any] = {"type": "raw"}
     if payload != "MISSING":
@@ -100,6 +141,11 @@ async def test_payload_type_none_passes_raw(
 
 @pytest.mark.asyncio()
 async def test_invalid_payload_calls_fallback() -> None:
+    """
+    Tests that an invalid payload type causes the message to be handled by the fallback method.
+    
+    Sends a message with an incorrect payload type to EchoResource and verifies that it is appended to the fallback list and not processed by the registered handler.
+    """
     r = EchoResource()
     raw = msgspec.json.encode({"type": "echo", "payload": {"text": 42}})
     await r.dispatch(DummyWS(), raw)

--- a/falcon_pachinko/unittests/test_websocket_resource.py
+++ b/falcon_pachinko/unittests/test_websocket_resource.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import typing
+
+import msgspec
+import pytest
+
+from falcon_pachinko.resource import WebSocketResource
+
+
+class EchoPayload(msgspec.Struct):
+    text: str
+
+
+class DummyWS:
+    pass
+
+
+class EchoResource(WebSocketResource):
+    def __init__(self) -> None:
+        self.seen: list[typing.Any] = []
+        self.fallback: list[typing.Any] = []
+
+    async def on_message(self, ws: typing.Any, message: str | bytes) -> None:
+        self.fallback.append(message)
+
+
+async def echo_handler(
+    self: EchoResource, ws: typing.Any, payload: EchoPayload
+) -> None:
+    self.seen.append(payload.text)
+
+
+EchoResource.add_handler("echo", echo_handler, payload_type=EchoPayload)
+
+
+@pytest.mark.asyncio()
+async def test_dispatch_calls_registered_handler() -> None:
+    r = EchoResource()
+    raw = msgspec.json.encode({"type": "echo", "payload": {"text": "hi"}})
+    await r.dispatch(DummyWS(), raw)
+    assert r.seen == ["hi"]
+    assert not r.fallback
+
+
+@pytest.mark.asyncio()
+async def test_dispatch_unknown_type_calls_fallback() -> None:
+    r = EchoResource()
+    raw = msgspec.json.encode({"type": "unknown", "payload": {"text": "oops"}})
+    await r.dispatch(DummyWS(), raw)
+    assert r.fallback == [raw]
+
+
+@pytest.mark.asyncio()
+async def test_handler_shared_across_instances() -> None:
+    r1 = EchoResource()
+    r2 = EchoResource()
+    raw = msgspec.json.encode({"type": "echo", "payload": {"text": "hey"}})
+    await r1.dispatch(DummyWS(), raw)
+    await r2.dispatch(DummyWS(), raw)
+    assert r1.seen == ["hey"]
+    assert r2.seen == ["hey"]

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -1,31 +1,27 @@
 from __future__ import annotations
 
+import typing
 from threading import Lock
 from types import MethodType
-from typing import Any
 
 
 class WebSocketConnectionManager:
     """Track active WebSocket connections."""
 
     def __init__(self) -> None:
-        """
-        Initialises the WebSocketConnectionManager with empty connection and room mappings.
-        
-        Creates dictionaries to track active WebSocket connections and group them into rooms.
-        """
-        self.connections: dict[str, Any] = {}
+        """Initialise empty connection and room mappings."""
+        self.connections: dict[str, typing.Any] = {}
         self.rooms: dict[str, set[str]] = {}
 
 
 # Public API ---------------------------------------------------------------
 
 
-def install(app: Any) -> None:
-    """
-    Attaches WebSocket management utilities to a Falcon app instance.
-    
-    Initialises and binds a WebSocket connection manager, a route mapping dictionary, and a method for registering WebSocket routes to the app. If the app already has all required WebSocket attributes, the function does nothing. If only some attributes are present, raises a RuntimeError to prevent inconsistent state.
+def install(app: typing.Any) -> None:
+    """Attach WebSocket utilities to ``app``.
+
+    Creates the connection manager and route registry. If only part of the
+    expected state is present, ``RuntimeError`` is raised.
     """
     wanted = (
         "ws_connection_manager",
@@ -43,7 +39,7 @@ def install(app: Any) -> None:
         raise RuntimeError("Partial WebSocket install detected; aborting.")
 
     app.ws_connection_manager = WebSocketConnectionManager()
-    routes: dict[str, Any] = {}
+    routes: dict[str, typing.Any] = {}
     app._websocket_routes = routes
     app.add_websocket_route = MethodType(_add_websocket_route, app)
 
@@ -51,11 +47,12 @@ def install(app: Any) -> None:
 _route_lock = Lock()
 
 
-def _add_websocket_route(self: Any, path: str, resource: Any) -> None:
+def _add_websocket_route(self: typing.Any, path: str, resource: typing.Any) -> None:
     """
     Registers a WebSocket resource handler for a specified path on the application.
-    
-    Ensures thread-safe registration and raises a ValueError if the path is already registered.
+
+    Ensures thread-safe registration and raises ``ValueError`` if ``path``
+    is already registered.
     """
     with _route_lock:
         if path in self._websocket_routes:

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -9,7 +9,9 @@ class WebSocketConnectionManager:
     """Track active WebSocket connections."""
 
     def __init__(self) -> None:
-        """Initialise empty connection and room mappings."""
+        """
+        Initializes the WebSocketConnectionManager with empty connection and room mappings.
+        """
         self.connections: dict[str, typing.Any] = {}
         self.rooms: dict[str, set[str]] = {}
 
@@ -18,10 +20,10 @@ class WebSocketConnectionManager:
 
 
 def install(app: typing.Any) -> None:
-    """Attach WebSocket utilities to ``app``.
-
-    Creates the connection manager and route registry. If only part of the
-    expected state is present, ``RuntimeError`` is raised.
+    """
+    Attaches WebSocket connection management and routing utilities to the given application.
+    
+    Initializes the connection manager and route registry on the app. If only some required attributes are present, raises RuntimeError to prevent inconsistent state.
     """
     wanted = (
         "ws_connection_manager",
@@ -49,10 +51,9 @@ _route_lock = Lock()
 
 def _add_websocket_route(self: typing.Any, path: str, resource: typing.Any) -> None:
     """
-    Registers a WebSocket resource handler for a specified path on the application.
-
-    Ensures thread-safe registration and raises ``ValueError`` if ``path``
-    is already registered.
+    Registers a WebSocket resource handler for the specified path on the application.
+    
+    Ensures thread-safe registration. Raises ``ValueError`` if the path is already registered.
     """
     with _route_lock:
         if path in self._websocket_routes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "falcon-pachinko package"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
-dependencies = []
+dependencies = ["msgspec>=0.18"]
 
 [project.optional-dependencies]
 dev = ["pytest", "ruff", "pyright"]


### PR DESCRIPTION
## Summary
- build structured WebSocketResource for message dispatch
- parse msgspec structs during dispatch
- mention msgspec in README and design docs
- add msgspec to project deps
- test WebSocketResource

## Testing
- `markdownlint README.md docs/falcon-websocket-extension-design.md`
- `nixie README.md docs/falcon-websocket-extension-design.md`
- `ruff check`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a31417af8832295ea4778eb6b5747

## Summary by Sourcery

Introduce a new WebSocketResource class with structured, typed message dispatch via msgspec, integrate msgspec as a dependency, update documentation to cover typed payloads, and add corresponding tests while refining existing WebSocket installation code.

New Features:
- Add WebSocketResource with typed message dispatch using msgspec

Enhancements:
- Refactor install and route registration to use typing.Any and improve docstrings
- Update existing WebSocket installation tests to use typing.cast and concise docstrings

Build:
- Add msgspec to project dependencies

Documentation:
- Mention msgspec-based typed payload parsing in README and design documentation

Tests:
- Add tests for WebSocketResource dispatch, handler registration, and fallback behavior