### PR TITLE
Update design doc for Falcon-Pachinko

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
-# Falcon-AsyncWS Roadmap
+# Falcon-Pachinko Roadmap
 
-This roadmap outlines the implementation tasks for the Falcon-AsyncWS extension.
+This roadmap outlines the implementation tasks for the Falcon-Pachinko extension.
 Line numbers refer to `docs/falcon-websocket-extension-design.md` after
 formatting.
 


### PR DESCRIPTION
## Summary
- update design docs to reference Falcon-Pachinko
- illustrate handles_message as a descriptor
- clarify typed payloads and update usage examples

## Testing
- `markdownlint docs/falcon-websocket-extension-design.md docs/roadmap.md`
- `nixie docs/falcon-websocket-extension-design.md docs/roadmap.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3fd7f67c8322910582a17857464c

## Summary by Sourcery

Update the design document and roadmap to rebrand 'Falcon-AsyncWS' as 'Falcon-Pachinko', clarify message payload typing, and illustrate the descriptor-based implementation of the handles_message decorator.

Enhancements:
- Rename all references from Falcon-AsyncWS to Falcon-Pachinko throughout the design doc and roadmap
- Document the descriptor implementation of the handles_message decorator for automatic handler registration
- Clarify typed payload handling by using msgspec.Struct definitions in examples
- Update code snippets to reflect typed payload usage and message handler examples

Documentation:
- Revise docs/falcon-websocket-extension-design.md to reference Falcon-Pachinko and enhance usage examples
- Update docs/roadmap.md to align with the new extension name and design changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated all references from "Falcon-AsyncWS" to "Falcon-Pachinko" in design and roadmap documents.
  - Expanded the design proposal to include a detailed example of message handler registration using a descriptor-based decorator.
  - Enhanced code examples to demonstrate type-safe message handling with typed payloads.
  - Clarified how typed payloads are deserialized for improved type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->