### PR TITLE
Add CodeScene upload to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    env:
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev] slipcover pytest-forked
+
+      - name: Check formatting
+        run: ruff format --check .
+
+      - name: Run ruff
+        run: ruff check .
+
+      - name: Run pyright
+        run: pyright
+
+      - name: Run tests with coverage
+        run: |
+          python -m slipcover \
+            --source=./falcon_pachinko \
+            --omit="*/unittests/*,*/.venv/*" \
+            --branch \
+            --out coverage.xml \
+            -m pytest --forked -v falcon_pachinko/unittests
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.xml
+
+      - name: Install CodeScene Coverage CLI
+        if: env.CS_ACCESS_TOKEN != ''
+        run: curl https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
+
+      - name: Upload coverage to CodeScene
+        if: env.CS_ACCESS_TOKEN != ''
+        run: |
+          if [ ! -f coverage.xml ]; then
+            echo "coverage.xml not found!"
+            exit 1
+          fi
+          cs-coverage upload \
+            --format "cobertura" \
+            --metric "line-coverage" \
+            coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,12 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install .[dev] slipcover pytest-forked
+          uv pip install --system .[dev] slipcover pytest-forked
 
       - name: Check formatting
         run: ruff format --check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install CodeScene Coverage CLI
         if: env.CS_ACCESS_TOKEN != ''
-        run: curl https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
+        run: curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
 
       - name: Upload coverage to CodeScene
         if: env.CS_ACCESS_TOKEN != ''

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -22,7 +22,7 @@ class WebSocketResource:
     def __init_subclass__(cls, **kwargs: typing.Any) -> None:
         """
         Initializes the handlers dictionary for each subclass of WebSocketResource.
-        
+
         Ensures that each subclass has its own independent mapping of message types to handler functions.
         """
         super().__init_subclass__(**kwargs)
@@ -33,12 +33,12 @@ class WebSocketResource:
     ) -> bool:
         """
         Called after the WebSocket handshake is complete to determine if the connection should be accepted.
-        
+
         Args:
             req: The incoming HTTP request associated with the WebSocket handshake.
             ws: The WebSocket connection object.
             **params: Additional parameters relevant to the connection.
-        
+
         Returns:
             True to accept the WebSocket connection; False to reject it.
         """
@@ -47,7 +47,7 @@ class WebSocketResource:
     async def on_disconnect(self, ws: typing.Any, close_code: int) -> None:
         """
         Handles cleanup or custom logic when the WebSocket connection is closed.
-        
+
         Args:
             ws: The WebSocket connection instance.
             close_code: The close code indicating the reason for disconnection.
@@ -56,7 +56,7 @@ class WebSocketResource:
     async def on_message(self, ws: typing.Any, message: str | bytes) -> None:
         """
         Handles incoming WebSocket messages that do not match any registered handler.
-        
+
         Called when a message cannot be decoded or its type is unrecognized. Override to implement custom fallback behavior for such messages.
         """
 
@@ -66,7 +66,7 @@ class WebSocketResource:
     ) -> None:
         """
         Registers a handler function for a specific message type.
-        
+
         Associates the given handler with the specified message type. Optionally, a payload type can be provided for automatic payload validation and conversion.
         """
         cls.handlers[message_type] = (handler, payload_type)
@@ -74,7 +74,7 @@ class WebSocketResource:
     async def dispatch(self, ws: typing.Any, raw: str | bytes) -> None:
         """
         Processes an incoming raw WebSocket message and dispatches it to the appropriate handler.
-        
+
         Attempts to decode the message as a JSON envelope containing a message type and optional payload. If decoding or payload validation fails, or if no handler is registered for the message type, the message is passed to the fallback `on_message` method. Otherwise, the registered handler is invoked with the converted payload.
         """
         try:

--- a/falcon_pachinko/unittests/test_app_install.py
+++ b/falcon_pachinko/unittests/test_app_install.py
@@ -22,13 +22,13 @@ class SupportsWebSocket(typing.Protocol):
     def create_websocket_resource(self, path: str) -> object:
         """
         Creates and returns a new instance of the WebSocket resource class registered for the specified path.
-        
+
         Args:
             path: The WebSocket route path for which to create a resource instance.
-        
+
         Returns:
             A new instance of the resource class associated with the given path.
-        
+
         Raises:
             ValueError: If no resource class is registered for the specified path.
         """
@@ -37,11 +37,11 @@ class SupportsWebSocket(typing.Protocol):
     def add_websocket_route(self, path: str, resource: type[object]) -> None:
         """
         Registers a WebSocketResource subclass to handle connections at the specified path.
-        
+
         Args:
             path: The WebSocket route path to register (must be a non-empty string starting with '/').
             resource: The class of the WebSocketResource to associate with the path.
-        
+
         Raises:
             ValueError: If the path is invalid or already registered.
             TypeError: If resource is not a subclass of WebSocketResource.
@@ -53,7 +53,7 @@ class SupportsWebSocket(typing.Protocol):
 def dummy_app() -> SupportsWebSocket:
     """
     Creates a dummy application instance with WebSocket support installed.
-    
+
     Returns:
         The dummy app instance cast to the SupportsWebSocket protocol, with WebSocket integration methods and attributes added.
     """
@@ -66,13 +66,14 @@ def dummy_app() -> SupportsWebSocket:
 def dummy_resource_cls(dummy_app: SupportsWebSocket) -> type[WebSocketResource]:
     """
     Creates and returns a dummy WebSocketResource subclass for testing purposes.
-    
+
     Args:
         dummy_app: The application instance supporting WebSocket features.
-    
+
     Returns:
         A subclass of WebSocketResource named DummyResource.
     """
+
     class DummyResource(WebSocketResource):
         pass
 
@@ -159,7 +160,7 @@ def test_add_websocket_route_invalid_path(
 ) -> None:
     """
     Tests that add_websocket_route raises ValueError when given an invalid path.
-    
+
     Verifies that attempting to register a WebSocket route with an invalid path value
     (such as missing a leading slash, being empty, containing only whitespace, or being a non-string)
     results in a ValueError.

--- a/falcon_pachinko/unittests/test_websocket_resource.py
+++ b/falcon_pachinko/unittests/test_websocket_resource.py
@@ -20,7 +20,7 @@ class EchoResource(WebSocketResource):
     def __init__(self) -> None:
         """
         Initializes the EchoResource with empty lists for handled and fallback messages.
-        
+
         The `seen` list stores texts from successfully handled payloads, while the `fallback` list records messages that do not match any registered handler or fail payload validation.
         """
         self.seen: list[typing.Any] = []
@@ -29,7 +29,7 @@ class EchoResource(WebSocketResource):
     async def on_message(self, ws: typing.Any, message: str | bytes) -> None:
         """
         Handles messages that do not match any registered handler by appending them to the fallback list.
-        
+
         Args:
             ws: The WebSocket connection instance.
             message: The raw message received, as a string or bytes.
@@ -42,7 +42,7 @@ async def echo_handler(
 ) -> None:
     """
     Handles an "echo" message by recording the payload text.
-    
+
     Appends the `text` field from the received `EchoPayload` to the resource's `seen` list.
     """
     self.seen.append(payload.text)
@@ -61,7 +61,7 @@ class RawResource(WebSocketResource):
     async def on_message(self, ws: typing.Any, message: str | bytes) -> None:
         """
         Handles incoming messages by appending them to the received list.
-        
+
         This method acts as a fallback for messages that do not match any registered handler.
         """
         self.received.append(message)
@@ -70,7 +70,7 @@ class RawResource(WebSocketResource):
 async def raw_handler(self: RawResource, ws: typing.Any, payload: typing.Any) -> None:
     """
     Handles incoming messages of type "raw" by appending the payload to the resource's received list.
-    
+
     Args:
         payload: The raw payload received with the message. Can be any type, including None.
     """
@@ -93,7 +93,7 @@ async def test_dispatch_calls_registered_handler() -> None:
 async def test_dispatch_unknown_type_calls_fallback() -> None:
     """
     Tests that dispatching a message with an unknown type invokes the fallback handler.
-    
+
     Verifies that when a message with an unregistered type is dispatched to EchoResource, the raw message is appended to the resource's fallback list.
     """
     r = EchoResource()
@@ -127,7 +127,7 @@ async def test_payload_type_none_passes_raw(
 ) -> None:
     """
     Tests that RawResource receives the raw payload as-is when no payload type is specified.
-    
+
     Verifies that the received list contains the exact payload passed, or None if the payload is missing.
     """
     r = RawResource()
@@ -143,7 +143,7 @@ async def test_payload_type_none_passes_raw(
 async def test_invalid_payload_calls_fallback() -> None:
     """
     Tests that an invalid payload type causes the message to be handled by the fallback method.
-    
+
     Sends a message with an incorrect payload type to EchoResource and verifies that it is appended to the fallback list and not processed by the registered handler.
     """
     r = EchoResource()

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -24,7 +24,7 @@ class WebSocketConnectionManager:
 def install(app: typing.Any) -> None:
     """
     Attaches WebSocket connection management and routing utilities to the application object.
-    
+
     Initializes and binds WebSocket-related attributes and methods to the given app, enabling WebSocket route registration and resource instantiation. This function is idempotent and will raise a RuntimeError if a partial installation is detected.
     """
     wanted = (
@@ -61,12 +61,12 @@ def _has_whitespace(text: str) -> bool:
 def _is_valid_route_path(path: typing.Any) -> bool:
     """
     Checks if the given path is a valid WebSocket route path.
-    
+
     A valid route path is a non-empty string that starts with '/', contains no leading or trailing whitespace, and has no internal whitespace characters.
-    
+
     Args:
         path: The value to check.
-    
+
     Returns:
         True if the path is a valid WebSocket route path, False otherwise.
     """
@@ -80,7 +80,7 @@ def _is_valid_route_path(path: typing.Any) -> bool:
 def _validate_route_path(path: typing.Any) -> None:
     """
     Validates that the given path is suitable for use as a WebSocket route.
-    
+
     Raises:
         ValueError: If the path is not a non-empty string starting with '/', contains whitespace, or has leading/trailing whitespace.
     """
@@ -92,7 +92,7 @@ def _validate_route_path(path: typing.Any) -> None:
 def _validate_resource_cls(resource_cls: typing.Any) -> None:
     """
     Validates that the provided class is a subclass of WebSocketResource.
-    
+
     Raises:
         TypeError: If resource_cls is not a subclass of WebSocketResource.
     """
@@ -110,7 +110,7 @@ def _validate_resource_cls(resource_cls: typing.Any) -> None:
 def _add_websocket_route(self: typing.Any, path: str, resource_cls: typing.Any) -> None:
     """
     Registers a WebSocketResource subclass for the specified route path.
-    
+
     Associates the given resource class with the provided path, ensuring the path is valid and not already registered. Raises a ValueError if the path is already in use.
     """
     _validate_route_path(path)
@@ -126,13 +126,13 @@ def _add_websocket_route(self: typing.Any, path: str, resource_cls: typing.Any) 
 def _create_websocket_resource(self: typing.Any, path: str) -> WebSocketResource:
     """
     Instantiates and returns the WebSocket resource class registered for the given path.
-    
+
     Args:
         path: The route path for which to create the WebSocket resource.
-    
+
     Returns:
         An instance of the resource class associated with the specified path.
-    
+
     Raises:
         ValueError: If no resource class is registered for the given path.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ select = [
     "B",
     "RUF",
 ]
+ignore = ["E501"]
 per-file-ignores = {"**/test_*.py" = ["S101"]}
 
 [tool.ruff.lint.flake8-import-conventions]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = { text = "MIT" }
 dependencies = ["msgspec>=0.18"]
 
 [project.optional-dependencies]
-dev = ["pytest", "ruff", "pyright"]
+dev = ["pytest", "pytest-asyncio", "ruff", "pyright"]
 
 [tool.pyright]
 pythonVersion = "3.13"


### PR DESCRIPTION
## Summary
- update CI to export `CS_ACCESS_TOKEN` from secrets
- install CodeScene CLI and upload coverage when token is present

## Testing
- `ruff check .`
- `ruff format --check .`
- `pyright`
- `python -m slipcover --source=./falcon_pachinko --omit="*/unittests/*,*/.venv/*" --branch --out coverage.xml -m pytest -q falcon_pachinko/unittests`


------
https://chatgpt.com/codex/tasks/task_e_684c0c1298008322b11d4d5e251f7e72

## Summary by Sourcery

Add a GitHub Actions CI workflow that runs formatting checks, linting, type-checking, unit tests with coverage, uploads the coverage artifact, and conditionally installs the CodeScene CLI to upload coverage when an access token is available.

Build:
- Update ruff configuration in pyproject.toml to ignore E501 line-length errors

CI:
- Add a CI workflow to run ruff format check, ruff lint, pyright, tests with coverage, and upload coverage.xml as an artifact
- Conditionally install and invoke the CodeScene Coverage CLI to upload coverage reports when CS_ACCESS_TOKEN is set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Introduced a continuous integration workflow for automated linting, testing, and code coverage reporting.
	- Updated linter configuration to ignore line length violations.
	- Cleaned up trailing whitespace in docstrings and comments across multiple files for improved formatting consistency.
	- Added support for asynchronous testing in development dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->