### PR TITLE
Add random_status example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ async def handle_new_chat_message(self, ws, payload):
 
 Implementation tasks are tracked in [docs/roadmap.md](docs/roadmap.md).
 
+## Examples
+
+An end-to-end demonstration lives under
+`examples/random_status`. It shows how to:
+
+- expose an HTTP endpoint returning the current status
+- handle a WebSocket message that updates that status in an
+  SQLite database
+- send a periodic "random" message from a background task.
+
+Run `server.py` with Uvicorn and connect using the provided
+`client.py` to observe the interaction.
+
 ## License
 
 This project is licensed under the terms of the ISC license.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ An end-to-end demonstration lives under
 
 - expose an HTTP endpoint returning the current status
 - handle a WebSocket message that updates that status in an
-  SQLite database
+  SQLite database using `aiosqlite`
 - send a periodic "random" message from a background task.
 
 Run `server.py` with Uvicorn and connect using the provided

--- a/examples/random_status/client.py
+++ b/examples/random_status/client.py
@@ -5,10 +5,20 @@ import websocket
 
 
 def on_message(ws: websocket.WebSocketApp, message: str) -> None:
+    """
+    Handles incoming messages from the WebSocket server.
+    
+    Prints each received message to standard output, prefixed with "<".
+    """
     print("<", message)
 
 
 def on_open(ws: websocket.WebSocketApp) -> None:
+    """
+    Sends a status message to the WebSocket server when the connection is opened.
+    
+    The status text is taken from the first command-line argument, or defaults to "hello" if not provided. The message is sent as a JSON object with "type" set to "status" and "payload" containing the status text.
+    """
     status = sys.argv[1] if len(sys.argv) > 1 else "hello"
     msg = json.dumps({"type": "status", "payload": {"text": status}})
     ws.send(msg)

--- a/examples/random_status/client.py
+++ b/examples/random_status/client.py
@@ -1,0 +1,23 @@
+import json
+import sys
+
+import websocket
+
+
+def on_message(ws: websocket.WebSocketApp, message: str) -> None:
+    print("<", message)
+
+
+def on_open(ws: websocket.WebSocketApp) -> None:
+    status = sys.argv[1] if len(sys.argv) > 1 else "hello"
+    msg = json.dumps({"type": "status", "payload": {"text": status}})
+    ws.send(msg)
+
+
+if __name__ == "__main__":
+    wsapp = websocket.WebSocketApp(
+        "ws://localhost:8000/ws",
+        on_open=on_open,
+        on_message=on_message,
+    )
+    wsapp.run_forever()

--- a/examples/random_status/server.py
+++ b/examples/random_status/server.py
@@ -25,6 +25,11 @@ class StatusPayload(typing.TypedDict):
 
 
 async def random_worker(ws: falcon.asgi.WebSocket) -> None:
+    """
+    Periodically sends random numbers to the client over a WebSocket connection.
+    
+    Runs indefinitely, sending a JSON message with a random number every 5 seconds until cancelled.
+    """
     try:
         while True:
             await asyncio.sleep(5)
@@ -39,16 +44,28 @@ async def random_worker(ws: falcon.asgi.WebSocket) -> None:
 
 class StatusResource(WebSocketResource):
     def __init__(self) -> None:
+        """
+        Initializes the StatusResource with no active background task.
+        """
         self._task: asyncio.Task[None] | None = None
 
     async def on_connect(
         self, req: falcon.Request, ws: falcon.asgi.WebSocket, **_: typing.Any
     ) -> bool:
+        """
+        Handles a new WebSocket connection by accepting it and starting a background task to send random numbers.
+        
+        Returns:
+            True to indicate the WebSocket connection has been accepted.
+        """
         await ws.accept()
         self._task = asyncio.create_task(random_worker(ws))
         return True
 
     async def on_disconnect(self, ws: falcon.asgi.WebSocket, close_code: int) -> None:
+        """
+        Handles cleanup when a WebSocket connection is closed by cancelling the background task if it exists.
+        """
         if self._task:
             self._task.cancel()
 
@@ -56,6 +73,11 @@ class StatusResource(WebSocketResource):
     async def update_status(
         self, ws: falcon.asgi.WebSocket, payload: StatusPayload
     ) -> None:
+        """
+        Handles incoming WebSocket "status" messages to update the stored status value.
+        
+        Updates the status in the database with the provided text and sends an acknowledgment message back to the client containing the updated value.
+        """
         text = payload["text"]
         await DB.execute("UPDATE status SET value=?", (text,))
         await DB.commit()
@@ -64,12 +86,23 @@ class StatusResource(WebSocketResource):
 
 class StatusEndpoint:
     async def on_get(self, req: falcon.Request, resp: falcon.Response) -> None:
+        """
+        Handles HTTP GET requests to retrieve the current status value.
+        
+        Responds with a JSON object containing the current status text from the database under the "status" key. If no status is set, the value is null.
+        """
         async with DB.execute("SELECT value FROM status") as cursor:
             row = await cursor.fetchone()
         resp.media = {"status": row[0] if row else None}
 
 
 def create_app() -> falcon.asgi.App:
+    """
+    Creates and configures the Falcon ASGI application with WebSocket and HTTP routes.
+    
+    Returns:
+        The configured Falcon ASGI application instance.
+    """
     app = falcon.asgi.App()
     install(app)
     app.add_websocket_route("/ws", StatusResource)

--- a/examples/random_status/server.py
+++ b/examples/random_status/server.py
@@ -1,0 +1,71 @@
+import asyncio
+import secrets
+import sqlite3
+import typing
+
+import falcon.asgi
+
+from falcon_pachinko import WebSocketResource, handles_message, install
+
+DB = sqlite3.connect(":memory:")
+DB.execute("CREATE TABLE status(value TEXT)")
+DB.execute("INSERT INTO status(value) VALUES('ready')")
+
+
+class StatusPayload(typing.TypedDict):
+    text: str
+
+
+async def random_worker(ws: falcon.asgi.WebSocket) -> None:
+    try:
+        while True:
+            await asyncio.sleep(5)
+            number = secrets.randbelow(65536)
+            await ws.send_media({"type": "random", "payload": str(number)})
+    except asyncio.CancelledError:
+        pass
+
+
+class StatusResource(WebSocketResource):
+    def __init__(self) -> None:
+        self._task: asyncio.Task[None] | None = None
+
+    async def on_connect(
+        self, req: falcon.Request, ws: falcon.asgi.WebSocket, **_: typing.Any
+    ) -> bool:
+        await ws.accept()
+        self._task = asyncio.create_task(random_worker(ws))
+        return True
+
+    async def on_disconnect(self, ws: falcon.asgi.WebSocket, close_code: int) -> None:
+        if self._task:
+            self._task.cancel()
+
+    @handles_message("status")
+    async def update_status(
+        self, ws: falcon.asgi.WebSocket, payload: StatusPayload
+    ) -> None:
+        text = payload["text"]
+        with DB:
+            DB.execute("UPDATE status SET value=?", (text,))
+        await ws.send_media({"type": "ack", "payload": text})
+
+
+class StatusEndpoint:
+    async def on_get(self, req: falcon.Request, resp: falcon.Response) -> None:
+        row = DB.execute("SELECT value FROM status").fetchone()
+        resp.media = {"status": row[0] if row else None}
+
+
+def create_app() -> falcon.asgi.App:
+    app = falcon.asgi.App()
+    install(app)
+    app.add_websocket_route("/ws", StatusResource)
+    app.add_route("/status", StatusEndpoint())
+    return app
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(create_app(), host="127.0.0.1", port=8000)


### PR DESCRIPTION
## Summary
- add a toy application under `examples/random_status`
- explain the example in README

## Testing
- `ruff format .`
- `ruff check .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9ea4d59c8322a67824596a63022c

## Summary by Sourcery

Add a new examples/random_status directory with server and client scripts demonstrating HTTP and WebSocket integration, and update documentation to explain how to run the example

Enhancements:
- Introduce a random_status example showcasing a Falcon ASGI server with an HTTP status endpoint, WebSocket-driven status updates stored in SQLite, and a background task sending periodic random messages

Documentation:
- Update README to include an Overview and instructions for the random_status example