### PR TITLE
Apply ruff formatting

### DIFF
--- a/examples/random_status/client.py
+++ b/examples/random_status/client.py
@@ -7,7 +7,7 @@ import websocket
 def on_message(ws: websocket.WebSocketApp, message: str) -> None:
     """
     Handles incoming messages from the WebSocket server.
-    
+
     Prints each received message to standard output, prefixed with "<".
     """
     print("<", message)
@@ -16,7 +16,7 @@ def on_message(ws: websocket.WebSocketApp, message: str) -> None:
 def on_open(ws: websocket.WebSocketApp) -> None:
     """
     Sends a status message to the WebSocket server when the connection is opened.
-    
+
     The status text is taken from the first command-line argument, or defaults to "hello" if not provided. The message is sent as a JSON object with "type" set to "status" and "payload" containing the status text.
     """
     status = sys.argv[1] if len(sys.argv) > 1 else "hello"

--- a/examples/random_status/server.py
+++ b/examples/random_status/server.py
@@ -27,7 +27,7 @@ class StatusPayload(typing.TypedDict):
 async def random_worker(ws: falcon.asgi.WebSocket) -> None:
     """
     Periodically sends random numbers to the client over a WebSocket connection.
-    
+
     Runs indefinitely, sending a JSON message with a random number every 5 seconds until cancelled.
     """
     try:
@@ -54,7 +54,7 @@ class StatusResource(WebSocketResource):
     ) -> bool:
         """
         Handles a new WebSocket connection by accepting it and starting a background task to send random numbers.
-        
+
         Returns:
             True to indicate the WebSocket connection has been accepted.
         """
@@ -75,7 +75,7 @@ class StatusResource(WebSocketResource):
     ) -> None:
         """
         Handles incoming WebSocket "status" messages to update the stored status value.
-        
+
         Updates the status in the database with the provided text and sends an acknowledgment message back to the client containing the updated value.
         """
         text = payload["text"]
@@ -88,7 +88,7 @@ class StatusEndpoint:
     async def on_get(self, req: falcon.Request, resp: falcon.Response) -> None:
         """
         Handles HTTP GET requests to retrieve the current status value.
-        
+
         Responds with a JSON object containing the current status text from the database under the "status" key. If no status is set, the value is null.
         """
         async with DB.execute("SELECT value FROM status") as cursor:
@@ -99,7 +99,7 @@ class StatusEndpoint:
 def create_app() -> falcon.asgi.App:
     """
     Creates and configures the Falcon ASGI application with WebSocket and HTTP routes.
-    
+
     Returns:
         The configured Falcon ASGI application instance.
     """


### PR DESCRIPTION
## Summary
- run `ruff format` on example clients

## Testing
- `ruff check`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ca920028083228b3d3c549be44582

## Summary by Sourcery

Enhancements:
- Format example client and server code with ruff, removing trailing whitespace and fixing spacing