### PR TITLE
Add WebSocket test utility design

### DIFF
--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -766,11 +766,11 @@ Such utilities would allow developers to:
 
 An initial API could include a `WebSocketSimulator` class that mimics a client
 connection using Falcon's ASGI test harness. The simulator would operate as an
-asynchronous context manager returning a connection object with helpers like
+asynchronous context manager, returning a connection object with helpers like
 `send_json()` and `receive_json()`. A convenience method,
 `simulate_websocket()`, on the standard test client would construct this
 simulator. Additionally, pytest fixtures should expose a ready-to-use simulator
-and manage background worker startup so tests can focus on asserting behaviour.
+and manage background worker startup, so tests can focus on asserting behaviour.
 
 ```mermaid
 sequenceDiagram

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -772,6 +772,52 @@ asynchronous context manager returning a connection object with helpers like
 simulator. Additionally, pytest fixtures should expose a ready-to-use simulator
 and manage background worker startup so tests can focus on asserting behaviour.
 
+```mermaid
+sequenceDiagram
+    actor Developer
+    participant TC as TestClient
+    participant WSSim as WebSocketSimulator
+    participant WSConn as WebSocketConnection
+    participant App as ASGIAppUnderTest
+
+    Developer->>TC: client.simulate_websocket()
+    activate TC
+    TC->>WSSim: new WebSocketSimulator()
+    TC-->>Developer: simulator
+    deactivate TC
+
+    Developer->>WSSim: async with simulator as conn:
+    activate WSSim
+    WSSim->>App: Establish Connection (via ASGI Test Harness)
+    activate App
+    WSSim-->>Developer: conn (WebSocketConnection instance)
+    deactivate WSSim
+
+    Developer->>WSConn: conn.send_json(data)
+    activate WSConn
+    WSConn->>App: Send JSON data
+    App-->>WSConn: (optional ack/response data)
+    deactivate App
+    WSConn-->>Developer: (return from send)
+    deactivate WSConn
+
+    Developer->>WSConn: data = conn.receive_json()
+    activate WSConn
+    WSConn->>App: Request/await data
+    activate App
+    App-->>WSConn: Send JSON data
+    deactivate App
+    WSConn-->>Developer: received_data
+    deactivate WSConn
+
+    Developer->>WSSim: (end of async with block / context exit)
+    activate WSSim
+    WSSim->>App: Close Connection
+    activate App
+    deactivate App
+    deactivate WSSim
+```
+
 ### 5.6. Automatic AsyncAPI Documentation Generation (Ambitious)
 
 As a long-term vision, the structured nature of `WebSocketResource` and the

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -764,6 +764,14 @@ Such utilities would allow developers to:
   otherwise be complex to test. Proactively considering these utilities enhances
   the library's completeness and professional appeal.
 
+An initial API could include a `WebSocketSimulator` class that mimics a client
+connection using Falcon's ASGI test harness. The simulator would operate as an
+asynchronous context manager returning a connection object with helpers like
+`send_json()` and `receive_json()`. A convenience method,
+`simulate_websocket()`, on the standard test client would construct this
+simulator. Additionally, pytest fixtures should expose a ready-to-use simulator
+and manage background worker startup so tests can focus on asserting behaviour.
+
 ### 5.6. Automatic AsyncAPI Documentation Generation (Ambitious)
 
 As a long-term vision, the structured nature of `WebSocketResource` and the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,6 +38,11 @@ formatting.
    - [ ] Develop tools similar to `falcon.testing` that simulate WebSocket
      clients for unit and integration tests.
    - [ ] Enable sending and receiving messages and verifying connection events.
+   - [ ] Provide a `WebSocketSimulator` class for opening connections to an ASGI
+     app under test.
+   - [ ] Expose `simulate_websocket()` on the test client API for convenience.
+   - [ ] Ship pytest fixtures for common patterns such as a reusable test client
+     and background worker hooks.
 
 6. **Illustrative Example**
 


### PR DESCRIPTION
## Summary
- expand design notes for test clients
- outline development subtasks for WebSocket testing utilities

## Testing
- `markdownlint docs/roadmap.md docs/falcon-websocket-extension-design.md`
- `nixie docs/roadmap.md docs/falcon-websocket-extension-design.md`


------
https://chatgpt.com/codex/tasks/task_e_684cde0e4eec8322a604ee2e598355c5

## Summary by Sourcery

Outline and document the design of WebSocket testing utilities and update the project roadmap with corresponding development tasks.

New Features:
- Design an initial WebSocketSimulator context manager API with send_json() and receive_json() helpers
- Introduce a simulate_websocket() convenience method on the standard test client

Enhancements:
- Propose pytest fixtures for reusable simulators and background worker management in tests

Documentation:
- Expand falcon-websocket-extension-design.md with detailed WebSocketSimulator API notes
- Update docs/roadmap.md with development subtasks for WebSocket testing utilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded design documentation to outline proposed WebSocket testing utilities, including a simulator class, helper methods, and pytest fixtures.
  - Updated the roadmap to include planned tasks for WebSocket testing support and related utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->