### PR TITLE
Fix markdown formatting

### DIFF
--- a/docs/guide-to-modern-python-code-coverage.md
+++ b/docs/guide-to-modern-python-code-coverage.md
@@ -1,40 +1,66 @@
-# Comprehensive Guide to Modern Python Code Coverage: Slipcover, Pytest, and CodeScene Integration
+# Comprehensive Guide to Modern Python Code Coverage
 
-In the dynamic landscape of software development, ensuring code quality and reliability is paramount. Code coverage, a metric that quantifies the proportion of a codebase exercised by automated tests, stands as a cornerstone of robust testing strategies.1 By illuminating untested code segments, developers and maintainers can strategically fortify test suites, thereby enhancing confidence in software correctness and stability. This guide delves into a powerful triad of tools—Slipcover, Pytest, and CodeScene—to establish an efficient and insightful code coverage analysis workflow, particularly within a Continuous Integration/Continuous Deployment (CI/CD) pipeline using GitHub Actions.
+## Slipcover, Pytest, and CodeScene Integration
+
+In the dynamic landscape of software development, ensuring code quality and
+reliability is paramount. Code coverage, a metric that quantifies the proportion
+of a codebase exercised by automated tests, stands as a cornerstone of robust
+testing strategies.1 By illuminating untested code segments, developers and
+maintainers can strategically fortify test suites, thereby enhancing confidence
+in software correctness and stability. This guide delves into a powerful triad
+of tools—Slipcover, Pytest, and CodeScene—to establish an efficient and
+insightful code coverage analysis workflow, particularly within a Continuous
+Integration/Continuous Deployment (CI/CD) pipeline using GitHub Actions.
 
 ## 1. Introduction to the Tooling Ecosystem
 
 Our journey to superior code coverage analysis involves three key players:
 
-- **Slipcover**: A high-performance Python code coverage tool designed for near-zero overhead. Its speed makes it ideal for frequent, even continuous, coverage analysis without significantly impacting development or CI build times.1
+- **Slipcover**: A high-performance Python code coverage tool designed for
+  near-zero overhead. Its speed makes it ideal for frequent, even continuous,
+  coverage analysis without significantly impacting development or CI build
+  times.1
 
-- **Pytest**: A mature, feature-rich Python testing framework favored for its simplicity and extensibility. We'll explore how to use Pytest effectively with Slipcover, including considerations for test isolation using `pytest-forked`.
+- **Pytest**: A mature, feature-rich Python testing framework favored for its
+  simplicity and extensibility. We'll explore how to use Pytest effectively with
+  Slipcover, including considerations for test isolation using `pytest-forked`.
 
-- **CodeScene**: An advanced code analysis platform that goes beyond raw coverage percentages. CodeScene contextualizes coverage data with insights into development hotspots, code health, and architectural dependencies, enabling teams to prioritize testing efforts where they yield the most impact.2
+- **CodeScene**: An advanced code analysis platform that goes beyond raw
+  coverage percentages. CodeScene contextualizes coverage data with insights
+  into development hotspots, code health, and architectural dependencies,
+  enabling teams to prioritize testing efforts where they yield the most
+  impact.2
 
-Automating this process with **GitHub Actions** will allow for seamless integration into the development lifecycle, providing timely feedback and fostering a culture of continuous quality assessment.
+Automating this process with **GitHub Actions** will allow for seamless
+integration into the development lifecycle, providing timely feedback and
+fostering a culture of continuous quality assessment.
 
 ## 2. Core Tooling: Slipcover for Coverage Collection
 
-Slipcover distinguishes itself with its remarkable speed, achieved through a C++ extension that instruments Python bytecode "just in time" (JIT), immediately before execution.1 This minimizes the overhead typically associated with coverage data collection.
+Slipcover distinguishes itself with its remarkable speed, achieved through a C++
+extension that instruments Python bytecode "just in time" (JIT), immediately
+before execution.1 This minimizes the overhead typically associated with
+coverage data collection.
 
 ### 2.1. Key Features of Slipcover
 
 1
 
-- **High Performance**: Near zero-overhead, making it suitable for all development and testing workflows.
+- **High Performance**: Near zero-overhead, making it suitable for all
+  development and testing workflows.
 
-- **Line and Branch Coverage**: Provides metrics for both lines of code executed and execution paths (branches) taken.
+- **Line and Branch Coverage**: Provides metrics for both lines of code executed
+  and execution paths (branches) taken.
 
-- **Multiple Output Formats**: Generates human-readable summaries, JSON, and, crucially for CI/CD, Cobertura XML.
+- **Multiple Output Formats**: Generates human-readable summaries, JSON, and,
+  crucially for CI/CD, Cobertura XML.
 
 ### 2.2. Installation
 
-Slipcover can be installed from the Python Package Index (PyPI) using pip. A C++ compiler is required on the system to build its native extension module.1
+Slipcover can be installed from the Python Package Index (PyPI) using pip. A C++
+compiler is required on the system to build its native extension module.1
 
-Bash
-
-```
+```bash
 pip install slipcover
 ```
 
@@ -46,104 +72,97 @@ Slipcover can execute Python scripts or modules directly:
 
 - **Running a script**:
 
-  Bash
-
-  ```
+  ```bash
   slipcover your_script.py
-  
   ```
 
 - **Running a module** (similar to `python -m`):
 
-  Bash
-
-  ```
+  ```bash
   slipcover -m your_package.your_module
-  
   ```
 
-By default, Slipcover prints a summary report to the console. For integration with other tools, specific report formats are essential:
+By default, Slipcover prints a summary report to the console. For integration
+with other tools, specific report formats are essential:
 
-- **Cobertura XML Report**: Vital for tools like CodeScene and other CI/CD integrations. Use the `--out` option:
+- **Cobertura XML Report**: Vital for tools like CodeScene and other CI/CD
+  integrations. Use the `--out` option:
 
-  Bash
-
-  ```
+  ```bash
   slipcover --out coverage.xml your_script.py
-  
   ```
 
 - **JSON Report**: For detailed programmatic access to coverage data:
 
-  Bash
-
-  ```
+  ```bash
   slipcover --json your_script.py > coverage.json
-  
   ```
 
-- **Branch Coverage**: To enable branch coverage analysis, add the `--branch` flag:
+- **Branch Coverage**: To enable branch coverage analysis, add the `--branch`
+  flag:
 
-  Bash
-
-  ```
+  ```bash
   slipcover --branch --out coverage.xml your_script.py
-  
   ```
 
 ### 2.4. Focusing Coverage with `--source` and `--omit`
 
 1
 
-To ensure coverage reports are meaningful and reflect the testing of your application code (and not, for example, the tests themselves or third-party libraries), use:
+To ensure coverage reports are meaningful and reflect the testing of your
+application code (and not, for example, the tests themselves or third-party
+libraries), use:
 
-- `--source <path>`: Restricts coverage measurement to files within the specified path(s).
+- `--source <path>`: Restricts coverage measurement to files within the
+  specified path(s).
 
 - `--omit <pattern>`: Excludes files matching the given wildcard pattern(s).
 
 **Example:**
 
-Bash
-
-```
+```bash
 slipcover --source=./my_app_src --omit="*/tests/*,*/venv/*" --branch --out coverage.xml -m pytest tests/
 ```
 
 ## 3. Test Execution with Pytest and Parallelization
 
-Pytest is a popular choice for running Python tests. Slipcover integrates with Pytest by running Pytest as a module.4
+Pytest is a popular choice for running Python tests. Slipcover integrates with
+Pytest by running Pytest as a module.4
 
 ### 3.1. Integrating Slipcover with Pytest
 
 The general command to run Pytest under Slipcover's watch is:
 
-Bash
-
-```
+```bash
 python -m slipcover -m pytest [pytest_arguments]
 ```
 
-For example, to generate a Cobertura XML report with branch coverage for tests in the `tests` directory, focusing on source code in `my_app_src`:
+For example, to generate a Cobertura XML report with branch coverage for tests
+in the `tests` directory, focusing on source code in `my_app_src`:
 
-Bash
-
-```
+```bash
 python -m slipcover --source=./my_app_src --omit="*/tests/*,*/venv/*" --branch --out coverage.xml -m pytest -v tests/
 ```
 
 ### 3.2. Leveraging `pytest-forked` for Test Isolation
 
-`pytest-forked` is a Pytest plugin that runs each test in a separate, isolated child process created by `fork()`. This is particularly useful for tests that might interfere with each other or have issues with global state. Slipcover version 1.0.4 and newer include support for `pytest-forked`.
+`pytest-forked` is a Pytest plugin that runs each test in a separate, isolated
+child process created by `fork()`. This is particularly useful for tests that
+might interfere with each other or have issues with global state. Slipcover
+version 1.0.4 and newer include support for `pytest-forked`.
 
 How Slipcover's pytest-forked Support Works (Internally):
 
-When pytest-forked creates child processes, Slipcover's enhanced capabilities ensure that:
+When pytest-forked creates child processes, Slipcover's enhanced capabilities
+ensure that:
 
-1. Each forked child process independently collects coverage data for the tests it executes.
+1. Each forked child process independently collects coverage data for the tests
+   it executes.
 
 2. This data is temporarily stored.
 
-3. Upon completion of all tests, the main Slipcover process aggregates the coverage data from all child processes into a single, unified dataset.
+3. Upon completion of all tests, the main Slipcover process aggregates the
+   coverage data from all child processes into a single, unified dataset.
 
 4. The final coverage report is generated from this aggregated data.
 
@@ -157,88 +176,112 @@ When pytest-forked creates child processes, Slipcover's enhanced capabilities en
 
    - `pytest-forked`
 
-   Bash
-
-   ```
+   ```bash
    pip install --upgrade slipcover pytest pytest-forked
-   
    ```
 
-   *Note:* `pytest-forked` *relies on the* `fork()` *system call, making it suitable for Unix-like systems (Linux, macOS).*
+   *Note:* `pytest-forked` *relies on the* `fork()` *system call, making it
+   suitable for Unix-like systems (Linux, macOS).*
 
 2. Command Invocation:
 
-   Add the --forked flag to your Pytest arguments when running through Slipcover.
+   Add the --forked flag to your Pytest arguments when running through
+   Slipcover.
 
-   Bash
-
+   ```bash
+   python -m slipcover \
+     --source=./my_app_src \
+     --omit="*/tests/*,*/venv/*" \
+     --branch \
+     --out coverage.xml \
+     -m pytest --forked -v tests/
    ```
-   python -m slipcover --source=./my_app_src --omit="*/tests/*,*/venv/*" --branch --out coverage.xml -m pytest --forked -v tests/
-   
-   ```
 
-   Slipcover will automatically handle the collection and aggregation of coverage data from the forked processes.
+   Slipcover will automatically handle the collection and aggregation of
+   coverage data from the forked processes.
 
 ### 3.3. Understanding `pytest-xdist` for Parallelism
 
-`pytest-xdist` is another popular Pytest plugin that enables running tests in parallel across multiple CPUs or even multiple machines, significantly speeding up test suite execution. It works by spawning worker processes, with a controller process managing the distribution of tests.5
+`pytest-xdist` is another popular Pytest plugin that enables running tests in
+parallel across multiple CPUs or even multiple machines, significantly speeding
+up test suite execution. It works by spawning worker processes, with a
+controller process managing the distribution of tests.5
 
 Current Slipcover Support Status for pytest-xdist:
 
-As of the latest information, Slipcover does not natively support pytest-xdist. The primary technical challenge is Slipcover's current inability to merge or coordinate coverage data collected from multiple, independent pytest-xdist worker processes into a single, coherent output.6 Attempting to use Slipcover with
+As of the latest information, Slipcover does not natively support pytest-xdist.
+The primary technical challenge is Slipcover's current inability to merge or
+coordinate coverage data collected from multiple, independent pytest-xdist
+worker processes into a single, coherent output.6 Attempting to use Slipcover
+with
 
-`pytest-xdist` typically results in partial or incomplete coverage reports.6 An enhancement request to address this is open (Slipcover GitHub issue #9).6
+`pytest-xdist` typically results in partial or incomplete coverage reports.6 An
+enhancement request to address this is open (Slipcover GitHub issue #9).6
 
 Developers needing `pytest-xdist`'s parallelism must currently choose between:
 
-- Using Slipcover for its performance but forgoing `pytest-xdist`'s parallel execution.
+- Using Slipcover for its performance but forgoing `pytest-xdist`'s parallel
+  execution.
 
-- Using an alternative coverage tool (like `coverage.py` with `pytest-cov` 8) that supports
+- Using an alternative coverage tool (like `coverage.py` with `pytest-cov` 8)
+  that supports
 
   `pytest-xdist`, potentially with higher instrumentation overhead.
 
 ## 4. Advanced Analysis with CodeScene
 
-CodeScene elevates coverage analysis by providing deep, contextual insights.9 It helps answer not just "what percentage is covered?" but "is the
+CodeScene elevates coverage analysis by providing deep, contextual insights.9 It
+helps answer not just "what percentage is covered?" but "is the
 
 *right* code covered effectively?"
 
 ### 4.1. Why CodeScene?
 
-- **Contextual Analysis**: Correlates coverage data with development hotspots (frequently changed and complex code), code health metrics, and team ownership.2
+- **Contextual Analysis**: Correlates coverage data with development hotspots
+  (frequently changed and complex code), code health metrics, and team
+  ownership.2
 
-- **Risk Identification**: Helps identify high-risk areas where low coverage poses the greatest threat.
+- **Risk Identification**: Helps identify high-risk areas where low coverage
+  poses the greatest threat.
 
-- **Prioritization**: Guides efforts to improve testing where it will have the most impact on quality and maintainability.
+- **Prioritization**: Guides efforts to improve testing where it will have the
+  most impact on quality and maintainability.
 
-CodeScene supports various coverage report formats, including the Cobertura XML format that Slipcover generates.2
+CodeScene supports various coverage report formats, including the Cobertura XML
+format that Slipcover generates.2
 
 ### 4.2. Prerequisites for CodeScene Integration
 
 1. **CodeScene Account and Project Setup**:
 
-   - Ensure your project is set up within a CodeScene instance (Cloud or On-Premises). CodeScene needs to be aware of your Git repository to correctly associate uploaded coverage data.3
+   - Ensure your project is set up within a CodeScene instance (Cloud or
+     On-Premises). CodeScene needs to be aware of your Git repository to
+     correctly associate uploaded coverage data.3
 
 2. **API Token Generation and Secure Storage**:
 
-   - Generate an API token from your CodeScene account. This token is used to authenticate uploads.12
+   - Generate an API token from your CodeScene account. This token is used to
+     authenticate uploads.12
 
-   - **Crucially, store this token as an encrypted secret in your GitHub repository** (e.g., named `CODESCENE_API_TOKEN`). Never hardcode it in workflow files. Access it in GitHub Actions via the `secrets` context (e.g., `${{ secrets.CODESCENE_API_TOKEN }}`).
+   - **Crucially, store this token as an encrypted secret in your GitHub
+     repository** (e.g., named `CODESCENE_API_TOKEN`). Never hardcode it in
+     workflow files. Access it in GitHub Actions via the `secrets` context
+     (e.g., `${{ secrets.CODESCENE_API_TOKEN }}`).
 
 ### 4.3. Uploading Slipcover's Cobertura XML to CodeScene
 
-CodeScene provides a dedicated command-line tool, the **CodeScene Coverage CLI (**`cs-coverage`**)**, which is the recommended method for uploading coverage data.11
+CodeScene provides a dedicated command-line tool, the **CodeScene Coverage CLI
+(**`cs-coverage`**)**, which is the recommended method for uploading coverage
+data.11
 
 - Installation of cs-coverage:
 
-  The tool can be installed using a script provided by CodeScene. In a GitHub Actions workflow, you might add a step like:
+  The tool can be installed using a script provided by CodeScene. In a GitHub
+  Actions workflow, you might add a step like:
 
-  YAML
-
-  ```
-        - name: Install CodeScene Coverage CLI
-          run: curl https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
-  
+  ```yaml
+  - name: Install CodeScene Coverage CLI
+    run: curl https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
   ```
 
   11
@@ -247,54 +290,70 @@ CodeScene provides a dedicated command-line tool, the **CodeScene Coverage CLI (
 
   The basic command to upload a Cobertura XML file is:
 
-  Bash
-
-  ```
-  cs-coverage upload --format "cobertura" --metric "line-coverage" "path/to/your/coverage.xml"
-  
+  ```bash
+  cs-coverage upload \
+    --format "cobertura" \
+    --metric "line-coverage" \
+    "path/to/your/coverage.xml"
   ```
 
   11
 
   - `--format "cobertura"`: Specifies the input file format.
 
-  - `--metric "line-coverage"`: Specifies the type of coverage metric being uploaded (line coverage is supported for Cobertura by `cs-coverage` 11).
+  - `--metric "line-coverage"`: Specifies the type of coverage metric being
+    uploaded (line coverage is supported for Cobertura by `cs-coverage` 11).
 
-  - `"path/to/your/coverage.xml"`: The path to the Slipcover-generated Cobertura XML file.
+  - `"path/to/your/coverage.xml"`: The path to the Slipcover-generated Cobertura
+    XML file.
 
 - Authentication:
 
-  The cs-coverage tool uses an environment variable CS_ACCESS_TOKEN for authentication. Ensure this variable is set with your CodeScene API token in the environment where the command is run.11 In GitHub Actions:
+  The cs-coverage tool uses an environment variable CS_ACCESS_TOKEN for
+  authentication. Ensure this variable is set with your CodeScene API token in
+  the environment where the command is run.11 In GitHub Actions:
 
-  YAML
-
-  ```
+  ```yaml
   env:
     CS_ACCESS_TOKEN: ${{ secrets.CODESCENE_API_TOKEN }}
-  
   ```
 
 - Alternative: Scripted REST API:
 
-  While the cs-coverage CLI is preferred for its simplicity and official support, CodeScene also offers a REST API for more direct interaction. This involves a two-step process: a POST request with metadata (commit SHA, repository URL, format, etc.) to get an upload reference, followed by a PUT request with the compressed (gzipped) coverage file.12 The CLI tool abstracts these complexities.
+  While the cs-coverage CLI is preferred for its simplicity and official
+  support, CodeScene also offers a REST API for more direct interaction. This
+  involves a two-step process: a POST request with metadata (commit SHA,
+  repository URL, format, etc.) to get an upload reference, followed by a PUT
+  request with the compressed (gzipped) coverage file.12 The CLI tool abstracts
+  these complexities.
 
 ### 4.4. Key Considerations for CodeScene Data
 
 10
 
-- **Commit Association**: CodeScene uses the commit SHA and repository URL to link coverage data to the correct version of your codebase. Ensure this metadata is accurate.
+- **Commit Association**: CodeScene uses the commit SHA and repository URL to
+  link coverage data to the correct version of your codebase. Ensure this
+  metadata is accurate.
 
-- **Relevance**: Coverage data is typically used if produced for the same commit being analyzed or an ancestor commit.
+- **Relevance**: Coverage data is typically used if produced for the same commit
+  being analyzed or an ancestor commit.
 
-- **Changes Since Coverage**: If a file has changed since the coverage data was generated (for an ancestor commit), CodeScene might not display coverage for that file.
+- **Changes Since Coverage**: If a file has changed since the coverage data was
+  generated (for an ancestor commit), CodeScene might not display coverage for
+  that file.
 
-- **No Merging for Single File**: CodeScene does not merge coverage data for a single file from different uploads. The most recent applicable upload for a file is used.
+- **No Merging for Single File**: CodeScene does not merge coverage data for a
+  single file from different uploads. The most recent applicable upload for a
+  file is used.
 
-- **Analysis Trigger**: Uploaded coverage data usually becomes visible in the Project Dashboard after CodeScene executes a new analysis for the project that includes the relevant commit.
+- **Analysis Trigger**: Uploaded coverage data usually becomes visible in the
+  Project Dashboard after CodeScene executes a new analysis for the project that
+  includes the relevant commit.
 
 ## 5. Automating with GitHub Actions
 
-A GitHub Actions workflow can automate the entire process: running tests, generating coverage, and uploading to CodeScene.
+A GitHub Actions workflow can automate the entire process: running tests,
+generating coverage, and uploading to CodeScene.
 
 ### 5.1. Workflow Overview
 
@@ -306,11 +365,10 @@ A typical workflow would:
 
 ### 5.2. Step-by-Step Workflow Configuration
 
-Here's an example structure for your workflow file (e.g., `.github/workflows/coverage_analysis.yml`):
+Here's an example structure for your workflow file (e.g.,
+`.github/workflows/coverage_analysis.yml`):
 
-YAML
-
-```
+```yaml
 name: Python Code Coverage Analysis
 
 on:
@@ -366,17 +424,19 @@ jobs:
 
 **Important Notes for the Workflow:**
 
-- Replace `your_project_src`, `tests/`, and other placeholders with your project's specific paths and configurations.
+- Replace `your_project_src`, `tests/`, and other placeholders with your
+  project's specific paths and configurations.
 
-- Ensure the `CODESCENE_API_TOKEN` secret is correctly set in your GitHub repository settings.
+- Ensure the `CODESCENE_API_TOKEN` secret is correctly set in your GitHub
+  repository settings.
 
 ### 5.3. (Optional) Adding PR Summaries
 
-For immediate feedback within GitHub pull requests, you can add a step to display a coverage summary. The `irongut/CodeCoverageSummary@v1.3.0` action is one option that can parse Cobertura XML files.13
+For immediate feedback within GitHub pull requests, you can add a step to
+display a coverage summary. The `irongut/CodeCoverageSummary@v1.3.0` action is
+one option that can parse Cobertura XML files.13
 
-YAML
-
-```
+```yaml
       - name: Post Coverage Summary Comment
         if: github.event_name == 'pull_request'
         uses: irongut/CodeCoverageSummary@v1.3.0
@@ -389,7 +449,8 @@ YAML
           thresholds: '60 80' # Example: red <60%, yellow <80%, green >=80%
 ```
 
-This provides a quick glance at coverage changes directly in the PR, complementing CodeScene's deeper analysis.
+This provides a quick glance at coverage changes directly in the PR,
+complementing CodeScene's deeper analysis.
 
 ## 6. Verification, Troubleshooting, and Best Practices
 
@@ -399,50 +460,83 @@ After a successful workflow run:
 
 1. Navigate to your project in CodeScene.
 
-2. Check the "Code Coverage" section or related views (often linked with Hotspots).
+2. Check the "Code Coverage" section or related views (often linked with
+   Hotspots).
 
 3. Verify that the data reflects the latest commit and seems accurate.
 
-4. Remember that a new CodeScene analysis might be needed for the data to appear on the dashboard.10
+4. Remember that a new CodeScene analysis might be needed for the data to appear
+   on the dashboard.10
 
 ### 6.2. Common Troubleshooting Tips
 
-- **API Token Issues**: 401/403 errors on upload usually mean an invalid or incorrectly configured `CS_ACCESS_TOKEN` or insufficient permissions for the token in CodeScene.12
+- **API Token Issues**: 401/403 errors on upload usually mean an invalid or
+  incorrectly configured `CS_ACCESS_TOKEN` or insufficient permissions for the
+  token in CodeScene.12
 
-- `cs-coverage` **CLI Issues**: Ensure it's installed correctly. Check command syntax, file paths, and that `coverage.xml` is generated and non-empty.
+- `cs-coverage` **CLI Issues**: Ensure it's installed correctly. Check command
+  syntax, file paths, and that `coverage.xml` is generated and non-empty.
 
-- **Metadata Mismatches**: If data uploads but doesn't appear correctly in CodeScene, double-check that the commit SHA and repository context are accurate. CodeScene relies on this for correct data association.10
+- **Metadata Mismatches**: If data uploads but doesn't appear correctly in
+  CodeScene, double-check that the commit SHA and repository context are
+  accurate. CodeScene relies on this for correct data association.10
 
-- **File Issues**: "coverage.xml not found" errors mean the Slipcover command failed or the path is wrong. Ensure Slipcover's `--source` and `--omit` are correctly configured for a valid report.
+- **File Issues**: "coverage.xml not found" errors mean the Slipcover command
+  failed or the path is wrong. Ensure Slipcover's `--source` and `--omit` are
+  correctly configured for a valid report.
 
-- **GitHub Actions Logs**: These are your first stop for debugging. Examine outputs from Slipcover, Pytest, and `cs-coverage` steps.
+- **GitHub Actions Logs**: These are your first stop for debugging. Examine
+  outputs from Slipcover, Pytest, and `cs-coverage` steps.
 
 ### 6.3. Best Practices
 
-- **Precise Slipcover Scope**: Diligently use `--source` and `--omit` to ensure Slipcover measures only your application code. This leads to more accurate and actionable insights.1
+- **Precise Slipcover Scope**: Diligently use `--source` and `--omit` to ensure
+  Slipcover measures only your application code. This leads to more accurate and
+  actionable insights.1
 
-- **Conditional Workflow Execution**: Consider running the full CodeScene upload only on pushes to main/default branches or on pull requests targeting these branches to optimize CI resources.
+- **Conditional Workflow Execution**: Consider running the full CodeScene upload
+  only on pushes to main/default branches or on pull requests targeting these
+  branches to optimize CI resources.
 
-- **Effective CodeScene Interpretation**: Focus on CodeScene's contextual analysis—coverage in Hotspots, correlation with Code Health, and trends over time—rather than just raw percentages.2
+- **Effective CodeScene Interpretation**: Focus on CodeScene's contextual
+  analysis—coverage in Hotspots, correlation with Code Health, and trends over
+  time—rather than just raw percentages.2
 
-- **API Token Rotation**: Periodically rotate your `CODESCENE_API_TOKEN` as a security best practice.
+- **API Token Rotation**: Periodically rotate your `CODESCENE_API_TOKEN` as a
+  security best practice.
 
-- **Managing Large Reports**: If `coverage.xml` becomes excessively large, refine `--source`/`--omit` further. CodeScene's API might also have size limits for uploads (often for compressed files, though `cs-coverage` may handle compression).10
+- **Managing Large Reports**: If `coverage.xml` becomes excessively large,
+  refine `--source`/`--omit` further. CodeScene's API might also have size
+  limits for uploads (often for compressed files, though `cs-coverage` may
+  handle compression).10
 
 ## 7. Conclusion: Elevating Code Quality Through Integrated Coverage
 
-Integrating Slipcover's high-performance coverage collection with Pytest's robust testing capabilities and CodeScene's advanced analytical insights, all automated within a GitHub Actions workflow, creates a formidable system for enhancing software quality.
+Integrating Slipcover's high-performance coverage collection with Pytest's
+robust testing capabilities and CodeScene's advanced analytical insights, all
+automated within a GitHub Actions workflow, creates a formidable system for
+enhancing software quality.
 
 This approach offers:
 
-- **Rapid Feedback**: Automated coverage analysis provides timely information to developers.
+- **Rapid Feedback**: Automated coverage analysis provides timely information to
+  developers.
 
-- **Efficient Collection**: Slipcover minimizes the performance impact of coverage measurement.1
+- **Efficient Collection**: Slipcover minimizes the performance impact of
+  coverage measurement.1
 
-- **Actionable Insights**: CodeScene transforms raw data into strategic guidance for testing and refactoring.2
+- **Actionable Insights**: CodeScene transforms raw data into strategic guidance
+  for testing and refactoring.2
 
-- **Improved Code Reliability**: A systematic focus on meaningful coverage leads to more resilient and maintainable software.
+- **Improved Code Reliability**: A systematic focus on meaningful coverage leads
+  to more resilient and maintainable software.
 
-While Slipcover's support for `pytest-xdist` is a current limitation to monitor 6, its compatibility with
+While Slipcover's support for `pytest-xdist` is a current limitation to monitor
+6, its compatibility with
 
-`pytest-forked` already provides a strong solution for many projects needing test isolation. By adopting and refining the practices outlined in this guide, development teams can foster a proactive approach to code quality, reduce technical debt, and deliver more dependable software. Continuously refer to the official documentation of each tool, as they evolve and introduce new capabilities.
+`pytest-forked` already provides a strong solution for many projects needing
+test isolation. By adopting and refining the practices outlined in this guide,
+development teams can foster a proactive approach to code quality, reduce
+technical debt, and deliver more dependable software. Continuously refer to the
+official documentation of each tool, as they evolve and introduce new
+capabilities.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 # Falcon-Pachinko Roadmap
 
-This roadmap outlines the implementation tasks for the Falcon-Pachinko extension.
-Line numbers refer to `docs/falcon-websocket-extension-design.md` after
-formatting.
+This roadmap outlines the implementation tasks for the Falcon-Pachinko
+extension. Line numbers refer to `docs/falcon-websocket-extension-design.md`
+after formatting.
 
 1. **Foundation and API Setup** (lines 140-170)
 


### PR DESCRIPTION
## Summary
- format docs using mdformat
- fix all markdownlint issues

## Testing
- `markdownlint docs/falcon-websocket-extension-design.md`
- `markdownlint docs/guide-to-modern-python-code-coverage.md`
- `markdownlint docs/roadmap.md`
- `mdformat-all`


------
https://chatgpt.com/codex/tasks/task_e_684f799b51c883228fba8808d949cb3c

## Summary by Sourcery

Reformat documentation files for consistent Markdown style and resolve lint errors

Documentation:
- Apply mdformat to standardize document layout and line wrapping
- Fix markdownlint issues by adding proper code fences, blank lines, and formatting lists and tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved formatting, readability, and consistency across multiple documentation files.
  - Enhanced code block syntax highlighting and bullet point structure.
  - Reformatted tables and sections for better clarity without changing content.
  - Made minor wording and whitespace adjustments for improved flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->