### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,11 @@ on:
 
 concurrency:
   group: release-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: write
 
-env:
-  REPO_NAME: ${{ github.event.repository.name }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build wheels for tags

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850c5b773d08322bd09af0363450885

## Summary by Sourcery

Add a GitHub Actions workflow to build and publish Python wheels for version tags

New Features:
- Trigger wheel builds on version tags across Linux, Windows, and macOS for x86_64 and aarch64 using cibuildwheel
- Automate GitHub release creation with autogenerated notes and upload of built wheel artifacts

CI:
- Define a matrix build strategy for multiple OS and architectures
- Use GitHub Actions steps for setup-python, cibuildwheel, artifact upload, and GitHub release actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced an automated release workflow to build and publish Python wheel files for multiple operating systems and architectures. Release assets are now attached to GitHub releases when new version tags are pushed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->