### PR TITLE
Fix cibuildwheel version range

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install build tooling
         run: |
           python -m pip install --upgrade pip
-          pip install 'cibuildwheel>=3.16.0,<4.0.0'
+          pip install 'cibuildwheel>=2.16.0,<4.0.0'
       - name: Build wheels
         run: |
           cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
## Summary
- fix the cibuildwheel version in the release workflow

## Testing
- `ruff format --diff .`
- `ruff check .`
- `pyright`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6851e389e1a883228eef52d409f1deb4

## Summary by Sourcery

CI:
- Update GitHub Actions to install cibuildwheel>=2.16.0,<4.0.0 in the release job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version requirements for a build tool in the release workflow to allow for a broader range of supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->