### PR TITLE
Use uvx in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb
       - name: Build wheels
         run: |
           uvx --with cibuildwheel>=2.16.0,<4.0.0 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-      - name: Install build tooling
-        run: |
-          python -m pip install --upgrade pip
-          pip install 'cibuildwheel>=3.16.0,<4.0.0'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Build wheels
         run: |
-          cibuildwheel --output-dir wheelhouse
+          uvx --with cibuildwheel>=3.16.0,<4.0.0 \
+            cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_SKIP: 'pp*'


### PR DESCRIPTION
## Summary
- install uv with `astral-sh/setup-uv`
- use `uvx` to run cibuildwheel instead of pip

## Testing
- `ruff format --check .`
- `ruff check .`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851e5dffba883228a3d9a416a7f9c46

## Summary by Sourcery

Use uvx in the release workflow to manage and run build tooling.

Enhancements:
- Remove direct pip installation of cibuildwheel in favor of uvx-managed execution

CI:
- Switch release workflow to install uv via astral-sh/setup-uv and invoke cibuildwheel through uvx instead of pip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the release workflow to use a new tool for building and installing dependencies. This change does not affect the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->