### PR TITLE
Remove CIBW_SKIP in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
           uvx --with 'cibuildwheel>=2.16.0,<4.0.0' cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
-          CIBW_SKIP: 'pp*'
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- remove unused `CIBW_SKIP` from release workflow

## Testing
- `ruff format .`
- `ruff check .`
- `pyright`
- `pytest -q` *(fails: ModuleNotFoundError: msgspec)*

------
https://chatgpt.com/codex/tasks/task_e_685292f6c6f48322810720e04069dcea

## Summary by Sourcery

CI:
- Remove unused CIBW_SKIP env var from release workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release workflow to include building wheels for all Python versions, removing the previous exclusion for certain versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->