### PR TITLE
Add checkout step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
   pure-wheel:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/pure-python-wheel
         with:
           python-version: '3.13'


### PR DESCRIPTION
## Summary
- check out repo before pure wheel job

## Testing
- `ruff format --check .`
- `ruff check .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585aaa141083229f274a93d9384008

## Summary by Sourcery

CI:
- Add checkout step before the pure-wheel job in the release workflow to fetch the repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the release workflow to ensure all necessary files are available during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->