### PR TITLE
Fix release workflow actions

### DIFF
--- a/.github/actions/build-wheels/action.yml
+++ b/.github/actions/build-wheels/action.yml
@@ -23,6 +23,7 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb
     - name: Build wheels
+      shell: bash
       run: |
         uvx --with 'cibuildwheel>=2.16.0,<4.0.0' cibuildwheel --output-dir wheelhouse
       env:

--- a/.github/actions/pure-python-wheel/action.yml
+++ b/.github/actions/pure-python-wheel/action.yml
@@ -24,6 +24,7 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb
     - name: Build wheel
+      shell: bash
       run: uv build --wheel --out-dir ${{ inputs.out-dir }}
     - name: Upload wheel artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- add the missing `shell: bash` option to composite GitHub actions

## Testing
- `ruff check .`
- `ruff format --diff .`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68588cf779008322a31e3ca803705d6c

## Summary by Sourcery

Ensure GitHub composite actions explicitly use the bash shell for their run steps.

CI:
- Add missing `shell: bash` setting to the Build wheels step in the build-wheels composite action
- Add missing `shell: bash` setting to the Build wheel step in the pure-python-wheel composite action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build automation workflows to explicitly use the Bash shell during wheel building steps for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->