### PR TITLE
Fix missing checkout in wheel workflow

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,6 +33,7 @@ jobs:
             arch: aarch64
             cibw_arch: arm64
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/build-wheels
         with:
           python-version: ${{ inputs['python-version'] }}


### PR DESCRIPTION
## Summary
- ensure repo is checked out before running the local wheel action

## Testing
- `ruff check .`
- `pyright` *(fails: Import "msgspec" could not be resolved, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c53b6c808322ba1249e5398b37f6

## Summary by Sourcery

CI:
- Add actions/checkout@v4 step to the build-wheels workflow before invoking the local wheel action