### PR TITLE
Disable binary wheel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,6 @@ permissions:
 
 
 jobs:
-  build:
-    uses: ./.github/workflows/build-wheels.yml
-    with:
-      python-version: '3.13'
 
   pure-wheel:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ async def handle_new_chat_message(self, ws, payload):
 ## Roadmap
 
 Implementation tasks are tracked in [docs/roadmap.md](docs/roadmap.md).
-See [docs/release-workflow.md](docs/release-workflow.md) for release details.
+See the [Release Workflow documentation](docs/release-workflow.md) for release
+details.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ async def handle_new_chat_message(self, ws, payload):
 ## Roadmap
 
 Implementation tasks are tracked in [docs/roadmap.md](docs/roadmap.md).
+See [docs/release-workflow.md](docs/release-workflow.md) for release details.
 
 ## Examples
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,8 +1,21 @@
 # Release Workflow
 
 The release workflow builds and publishes a pure Python wheel.
-Binary wheels for specific architectures are no longer produced.
+Binary wheels for specific architectures are no longer produced. The
+cross-platform `build` job in `.github/workflows/release.yml` was disabled to
+avoid unnecessary maintenance, since the project contains no C or Rust code.
 
-The process runs automatically when a git tag matching `v*.*.*` is pushed.
-It builds the wheel using `uv build`, uploads the artifact, and attaches it
-to a GitHub release.
+The process runs automatically when a git tag matching `v*.*.*` is pushed. For
+example:
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+Once triggered, GitHub Actions performs the release steps:
+
+```bash
+uv build
+# the wheel artifact is uploaded and attached to the GitHub release
+```

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,0 +1,8 @@
+# Release Workflow
+
+The release workflow builds and publishes a pure Python wheel.
+Binary wheels for specific architectures are no longer produced.
+
+The process runs automatically when a git tag matching `v*.*.*` is pushed.
+It builds the wheel using `uv build`, uploads the artifact, and attaches it
+to a GitHub release.


### PR DESCRIPTION
## Summary
- disable the `build` job in the release workflow so cibuildwheel won't run
- document the simplified release process
- mention the release doc in the README

## Testing
- `ruff check falcon_pachinko`
- `pyright` *(fails: Import "msgspec" could not be resolved)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'falcon_pachinko')*
- `markdownlint README.md docs/release-workflow.md`
- `nixie README.md docs/release-workflow.md`


------
https://chatgpt.com/codex/tasks/task_e_6858c99e098c8322935da1779f212e9f

## Summary by Sourcery

Disable binary wheel builds in the release workflow and provide updated documentation for the streamlined release process.

CI:
- Disable binary wheel build job in the release workflow

Documentation:
- Add a release-workflow.md doc outlining the simplified release process
- Reference the new release documentation in the README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new document detailing the release workflow.
  - Updated the README with a link to the release workflow documentation.

- **Chores**
  - Simplified the release process by removing an external build job from the workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->