### PR TITLE
Add route-specific resource parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ for the full design rationale.
 ## Key features
 
 - `app.add_websocket_route()` maps WebSocket paths to `WebSocketResource`
-  classes, mirroring Falcon's HTTP routing.
+  classes, mirroring Falcon's HTTP routing. Initialization parameters can be
+  supplied so one resource class supports multiple configurations.
 - `WebSocketResource` provides `on_connect`, `on_disconnect`, and
   `on_message` lifecycle hooks.
 - Message payloads are parsed into `msgspec.Struct` classes for speed and type
@@ -26,7 +27,8 @@ for the full design rationale.
 These concepts are summarised in the design document:
 
 ```python
-app.add_websocket_route('/ws/chat/{room_name}', ChatRoomResource())
+# pass route-specific options to the resource
+app.add_websocket_route('/ws/chat/{room_name}', ChatRoomResource, history_size=100)
 ```
 
 ```python

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ for the full design rationale.
 
 - `app.add_websocket_route()` maps WebSocket paths to `WebSocketResource`
   classes, mirroring Falcon's HTTP routing. Initialization parameters can be
-  supplied so one resource class supports multiple configurations.
+  supplied, so one resource class supports multiple configurations.
 - `WebSocketResource` provides `on_connect`, `on_disconnect`, and
   `on_message` lifecycle hooks.
 - Message payloads are parsed into `msgspec.Struct` classes for speed and type

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -192,13 +192,17 @@ Analogous to Falcon's HTTP routing (`app.add_route()`), the extension will
 provide a method to associate a URL path with a `WebSocketResource`:
 
 ```python
-app.add_websocket_route('/ws/chat/{room_name}', ChatRoomResource())
+app.add_websocket_route(
+    '/ws/chat/{room_name}',
+    ChatRoomResource,
+    history_size=100,
+)
 ```
 
 When a WebSocket upgrade request matches this path, Falcon-Pachinko will
-instantiate the `ChatRoomResource` and manage the WebSocket lifecycle through
-it. Path parameters like `{room_name}` will be passed to the relevant methods of
-the `WebSocketResource`.
+instantiate `ChatRoomResource` using the given arguments and manage the
+connection lifecycle. Path parameters like `{room_name}` and the
+`history_size` option will be passed to the resource's constructor and methods.
 
 #### 3.4.1. Programmatic Resource Instantiation
 
@@ -451,7 +455,7 @@ and their intended use.
 | Component/Concept                | Key Classes/Decorators/Methods                                                                                              | Purpose                                                                                                       | Analogy to Falcon HTTP (if applicable)                                                                                              |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | Application Setup                | `falcon_pachinko.install(app)`                                                                                              | Initializes shared WebSocket components (e.g., connection manager) on the app.                                | App-level configuration/extensions.                                                                                                 |
-| Route Definition                 | `app.add_websocket_route(path, resource_class_instance)`                                                                    | Maps a URI path to a `WebSocketResource`.                                                                     | `app.add_route(path, resource_instance)`                                                                                            |
+| Route Definition                 | `app.add_websocket_route(path, resource_class, *args, **kwargs)`                                                                    | Maps a URI path to a `WebSocketResource` with optional initialization parameters.                                                                     | `app.add_route(path, resource_instance)`                                                                                            |
 | Resource Instantiation           | `app.create_websocket_resource(path)`                                                                                       | Returns a new resource instance for the given path.                                                           | N/A                                                                                                                                 |
 | Resource Class                   | `falcon_pachinko.WebSocketResource`                                                                                         | Base class for handling WebSocket connections and messages for a given route.                                 | Falcon HTTP Resource class (e.g., methods like `on_get`, `on_post` handle specific `falcon.HTTP_METHODS`).                          |
 | Connection Lifecycle             | `async def on_connect(req, ws, **params) -> bool`, `async def on_disconnect(ws, close_code)`                                | Methods in `WebSocketResource` to manage connection setup and teardown.                                       | `process_request` / `process_response` middleware (for setup/teardown aspects), though more directly tied to the connection itself. |

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -200,9 +200,10 @@ app.add_websocket_route(
 ```
 
 When a WebSocket upgrade request matches this path, Falcon-Pachinko will
-instantiate `ChatRoomResource` using the given arguments and manage the
-connection lifecycle. Path parameters like `{room_name}` and the
-`history_size` option will be passed to the resource's constructor and methods.
+instantiate `ChatRoomResource` with the provided arguments and manage the
+connection lifecycle. Path parameters like `{room_name}` are supplied to the
+resource's `on_*` methods, while options such as `history_size` are applied
+during construction.
 
 ```mermaid
 sequenceDiagram

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -204,6 +204,19 @@ instantiate `ChatRoomResource` using the given arguments and manage the
 connection lifecycle. Path parameters like `{room_name}` and the
 `history_size` option will be passed to the resource's constructor and methods.
 
+```mermaid
+sequenceDiagram
+    actor Developer
+    participant App
+    participant WebSocketConnectionManager as Manager
+    participant RouteSpec
+
+    Developer->>App: add_websocket_route(path, resource_cls, *args, **kwargs)
+    App->>Manager: _add_websocket_route(path, resource_cls, *args, **kwargs)
+    Manager->>RouteSpec: create RouteSpec(resource_cls, args, kwargs)
+    Manager->>Manager: Store RouteSpec in _websocket_routes[path]
+```
+
 #### 3.4.1. Programmatic Resource Instantiation
 
 Application code can also create a resource instance directly using
@@ -216,6 +229,20 @@ chat_resource = app.create_websocket_resource('/ws/chat/{room_name}')
 
 Each call yields a fresh instance so that connection-specific state can be
 maintained independently.
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant WebSocketConnectionManager as Manager
+    participant RouteSpec
+    participant WebSocketResource as Resource
+
+    App->>Manager: create_websocket_resource(path)
+    Manager->>Manager: Lookup RouteSpec in _websocket_routes[path]
+    Manager->>RouteSpec: Access resource_cls, args, kwargs
+    Manager->>Resource: Instantiate resource_cls(*args, **kwargs)
+    Manager-->>App: Return Resource instance
+```
 
 ### 3.5. The `WebSocketResource` Class
 

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
+import dataclasses as dc
 import typing
 from threading import Lock
 from types import MethodType
 
 from .resource import WebSocketResource
+
+
+@dc.dataclass(slots=True)
+class RouteSpec:
+    """Hold configuration for a WebSocket route."""
+
+    resource_cls: type[WebSocketResource]
+    args: tuple[typing.Any, ...] = ()
+    kwargs: dict[str, typing.Any] = dc.field(default_factory=dict[str, typing.Any])
 
 
 class WebSocketConnectionManager:
@@ -45,8 +55,7 @@ def install(app: typing.Any) -> None:
         raise RuntimeError("Partial WebSocket install detected; aborting.")
 
     app.ws_connection_manager = WebSocketConnectionManager()
-    routes: dict[str, typing.Any] = {}
-    app._websocket_routes = routes
+    app._websocket_routes = typing.cast("dict[str, RouteSpec]", {})
     app.add_websocket_route = MethodType(_add_websocket_route, app)
     app.create_websocket_resource = MethodType(_create_websocket_resource, app)
     app._websocket_route_lock = Lock()
@@ -107,11 +116,19 @@ def _validate_resource_cls(resource_cls: typing.Any) -> None:
         raise TypeError(msg)
 
 
-def _add_websocket_route(self: typing.Any, path: str, resource_cls: typing.Any) -> None:
+def _add_websocket_route(
+    self: typing.Any,
+    path: str,
+    resource_cls: typing.Any,
+    *init_args: typing.Any,
+    **init_kwargs: typing.Any,
+) -> None:
     """
-    Registers a WebSocketResource subclass for the specified route path.
+    Registers ``resource_cls`` to handle connections for ``path``.
 
-    Associates the given resource class with the provided path, ensuring the path is valid and not already registered. Raises a ValueError if the path is already in use.
+    Any ``init_args`` or ``init_kwargs`` supplied are stored and applied when
+    ``create_websocket_resource`` is called. This allows a single resource class
+    to be configured differently across multiple routes.
     """
     _validate_route_path(path)
     _validate_resource_cls(resource_cls)
@@ -120,28 +137,36 @@ def _add_websocket_route(self: typing.Any, path: str, resource_cls: typing.Any) 
             msg = f"WebSocket route already registered for path: {path}"
             raise ValueError(msg)
 
-        self._websocket_routes[path] = resource_cls
+        self._websocket_routes[path] = RouteSpec(
+            resource_cls,
+            init_args,
+            dict(init_kwargs),
+        )
 
 
 def _create_websocket_resource(self: typing.Any, path: str) -> WebSocketResource:
     """
-    Instantiates and returns the WebSocket resource class registered for the given path.
+    Instantiates and returns the WebSocket resource registered for ``path``.
+
+    Initialization parameters provided to :func:`add_websocket_route` are
+    forwarded to the resource constructor.
 
     Args:
-        path: The route path for which to create the WebSocket resource.
+        path: The route path for which to create the resource.
 
     Returns:
-        An instance of the resource class associated with the specified path.
+        A new instance of the resource associated with ``path``.
 
     Raises:
-        ValueError: If no resource class is registered for the given path.
+        ValueError: If no resource class is registered for ``path``.
     """
     with self._websocket_route_lock:
+        routes = typing.cast("dict[str, RouteSpec]", self._websocket_routes)
         try:
-            resource_cls = self._websocket_routes[path]
+            entry = routes[path]
         except KeyError as exc:
             raise ValueError(
                 f"No WebSocket resource registered for path: {path}"
             ) from exc
 
-    return resource_cls()
+    return entry.resource_cls(*entry.args, **entry.kwargs)

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -8,8 +8,8 @@ from types import MethodType
 from .resource import WebSocketResource
 
 
-def _new_kwargs_dict() -> dict[str, typing.Any]:
-    """Return a fresh kwargs dict with a precise type."""
+def _kwargs_factory() -> dict[str, typing.Any]:
+    """Return a new kwargs dict with a precise type."""
 
     return {}
 
@@ -20,7 +20,7 @@ class RouteSpec:
 
     resource_cls: type[WebSocketResource]
     args: tuple[typing.Any, ...] = ()
-    kwargs: dict[str, typing.Any] = dc.field(default_factory=_new_kwargs_dict)
+    kwargs: dict[str, typing.Any] = dc.field(default_factory=_kwargs_factory)
 
 
 class WebSocketConnectionManager:


### PR DESCRIPTION
## Summary
- allow passing init parameters in `add_websocket_route`
- store init args/kwargs with a `RouteSpec` dataclass
- document route-specific configuration with examples

## Testing
- `ruff format .`
- `ruff check .`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a7a566a0c8322a5fa21c425490b60

## Summary by Sourcery

Allow each WebSocket route to be configured with custom initialization parameters by extending `add_websocket_route`, storing route information in a new `RouteSpec` dataclass, and forwarding those parameters when instantiating resources.

New Features:
- Accept `*init_args` and `**init_kwargs` in `add_websocket_route` to supply per-route resource initialization parameters.
- Introduce `RouteSpec` dataclass to encapsulate a WebSocket resource class along with its init args and kwargs.
- Modify `create_websocket_resource` to instantiate resources with the stored args and kwargs from `RouteSpec`.

Enhancements:
- Change the internal `_websocket_routes` mapping to store `RouteSpec` objects instead of raw resource classes.
- Update documentation (design document and README) with examples, updated route definition syntax, and sequence diagrams illustrating the new flow.

Tests:
- Add a test (`test_route_specific_init_args`) to verify route-specific init parameters are forwarded correctly.
- Update existing tests to assert that `RouteSpec` entries hold the correct resource class and initialization parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified and updated documentation to show that WebSocket routes can now be registered with resource classes and route-specific initialization parameters.
  - Revised example usage and API overview to reflect the ability to pass arguments and keyword options per route.
  - Added sequence diagrams illustrating WebSocket route registration and resource instantiation flows.

- **New Features**
  - Enabled registering WebSocket routes with resource classes and custom initialization parameters, allowing different routes to configure the same resource class differently.

- **Tests**
  - Enhanced and added tests to verify that route-specific initialization arguments are correctly stored and used when creating WebSocket resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->