### PR TITLE
Add websocket module documentation

### DIFF
--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -4,8 +4,7 @@ This module extends a Falcon application with helpers for registering
 ``WebSocketResource`` classes under specific route paths and for instantiating
 them on demand. It also provides ``WebSocketConnectionManager`` to track active
 connections and organize them into rooms. The overall design rationale for this
-approach is documented in
-``docs/falcon-websocket-extension-design.md``.
+approach is documented in :doc:`falcon-websocket-extension-design`.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- document connection management and routing utilities in the `websocket` module

## Testing
- `ruff check falcon_pachinko/websocket.py`
- `pyright`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca20b57488322a35d91454f96ed29

## Summary by Sourcery

Documentation:
- Add module-level docs explaining connection lifecycle and routing utilities in the websocket module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive module description to the WebSocket utilities, clarifying their purpose and usage within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->