### PR TITLE
Introduce WebSocket protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --system .[dev] slipcover pytest-forked
+          uv pip install --system --group dev .
+          uv pip install --system slipcover pytest-forked
 
       - name: Check formatting
         run: ruff format --check .

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -256,7 +256,9 @@ logic.
   - `async def on_connect(self, req, ws, **params) -> bool`: WebSocket
     connection is established and routed to this resource. `req` is the standard
     Falcon `Request` object associated with the initial HTTP upgrade request,
-    and `ws` is the `falcon.asgi.WebSocket` object. `params` will contain any
+    and `ws` is a **`WebSocketLike` connection**. The protocol defines the
+    minimal `send`, `accept`, and `close` methods needed by the resource.
+    `params` will contain any
     path parameters from the route. The method should return `True` to accept
     the connection or `False` to reject it. If `False` is returned, the library
     will handle sending an appropriate closing handshake (e.g., HTTP 403 or a
@@ -267,11 +269,11 @@ logic.
     Falcon's higher-level approach for HTTP handlers, where the framework
     manages response sending.
 
-  - `async def on_disconnect(self, ws: falcon.asgi.WebSocket, close_code: int)`:
+  - `async def on_disconnect(self, ws: WebSocketLike, close_code: int)`:
     Called when the WebSocket connection is closed, either by the client or the
     server. `close_code` provides the WebSocket close code.
 
-  - `async def on_message(self, ws: falcon.asgi.WebSocket, message: Union[str, bytes])`:
+  - `async def on_message(self, ws: WebSocketLike, message: Union[str, bytes])`:
         <!-- markdownlint-disable-line MD013 --> A fallback handler for messages
     that are not dispatched by the more specific message handlers (see below).
     This can be used for raw text/binary data or messages that don't conform to
@@ -298,7 +300,7 @@ a monolithic `on_receive` method with extensive conditional logic.
   handlers for specific message types:
 
   ```python
-  from falcon_pachinko import WebSocketResource, handles_message
+  from falcon_pachinko import WebSocketLike, WebSocketResource, handles_message
   import msgspec
 
   class NewChatMessage(msgspec.Struct):
@@ -310,14 +312,14 @@ a monolithic `on_receive` method with extensive conditional logic.
   class ChatMessageHandler(WebSocketResource):
       @handles_message("new_chat_message")
       async def handle_new_chat_message(
-          self, ws: falcon.asgi.WebSocket, payload: NewChatMessage
+          self, ws: WebSocketLike, payload: NewChatMessage
       ) -> None:
           text = payload.text
           print(f"NEW MESSAGE: {text}")
 
       @handles_message("user_status_update")
       async def handle_status_update(
-          self, ws: falcon.asgi.WebSocket, payload: StatusUpdate
+          self, ws: WebSocketLike, payload: StatusUpdate
       ) -> None:
           print(f"JOINED ROOM: {payload.room}")
 
@@ -535,10 +537,10 @@ A `ChatRoomResource` class would be defined, inheriting from
 
 ```python
 import falcon.asgi
-from falcon_pachinko import WebSocketResource, handles_message
+from falcon_pachinko import WebSocketLike, WebSocketResource, handles_message
 
 class ChatRoomResource(WebSocketResource):
-    async def on_connect(self, req: falcon.Request, ws: falcon.asgi.WebSocket, room_name: str) -> bool: <!-- markdownlint-disable-line MD013 -->
+    async def on_connect(self, req: falcon.Request, ws: WebSocketLike, room_name: str) -> bool: <!-- markdownlint-disable-line MD013 -->
         # Assume authentication middleware has set req.context.user
         self.user = req.context.get("user")
         if not self.user:
@@ -564,7 +566,7 @@ class ChatRoomResource(WebSocketResource):
         return True
 
     @handles_message("clientSendMessage")
-    async def handle_client_send_message(self, ws: falcon.asgi.WebSocket, payload: dict): <!-- markdownlint-disable-line MD013 -->
+    async def handle_client_send_message(self, ws: WebSocketLike, payload: dict): <!-- markdownlint-disable-line MD013 -->
         message_text = payload.get("text", "")
         # Add validation/sanitization as needed
         await self.broadcast_to_room(
@@ -573,7 +575,7 @@ class ChatRoomResource(WebSocketResource):
         )
 
     @handles_message("clientStartTyping")
-    async def handle_client_start_typing(self, ws: falcon.asgi.WebSocket, payload: dict): <!-- markdownlint-disable-line MD013 -->
+    async def handle_client_start_typing(self, ws: WebSocketLike, payload: dict): <!-- markdownlint-disable-line MD013 -->
         await self.broadcast_to_room(
             self.room_name,
             {"type": "serverUserTyping", "payload": {"user": self.user.name, "isTyping": True}}, <!-- markdownlint-disable-line MD013 -->
@@ -581,14 +583,14 @@ class ChatRoomResource(WebSocketResource):
         )
 
     @handles_message("clientStopTyping")
-    async def handle_client_stop_typing(self, ws: falcon.asgi.WebSocket, payload: dict): <!-- markdownlint-disable-line MD013 -->
+    async def handle_client_stop_typing(self, ws: WebSocketLike, payload: dict): <!-- markdownlint-disable-line MD013 -->
         await self.broadcast_to_room(
             self.room_name,
             {"type": "serverUserTyping", "payload": {"user": self.user.name, "isTyping": False}}, <!-- markdownlint-disable-line MD013 -->
             exclude_self=True
         )
 
-    async def on_disconnect(self, ws: falcon.asgi.WebSocket, close_code: int):
+    async def on_disconnect(self, ws: WebSocketLike, close_code: int):
         if hasattr(self, 'room_name') and hasattr(self, 'user'): # Ensure on_connect completed successfully <!-- markdownlint-disable-line MD013 -->
             await self.broadcast_to_room(
                 self.room_name,
@@ -598,7 +600,7 @@ class ChatRoomResource(WebSocketResource):
             await self.leave_room(self.room_name) # Uses connection manager
         print(f"User {getattr(self.user, 'name', 'Unknown')} disconnected from room {getattr(self, 'room_name', 'N/A')} with code {close_code}") <!-- markdownlint-disable-line MD013 -->
 
-    async def on_message(self, ws: falcon.asgi.WebSocket, message: Union[str, bytes]): <!-- markdownlint-disable-line MD013 -->
+    async def on_message(self, ws: WebSocketLike, message: Union[str, bytes]): <!-- markdownlint-disable-line MD013 -->
         # Fallback for messages not matching handled types or non-JSON
         print(f"Received unhandled message from {self.user.name} in {self.room_name}: {message}") <!-- markdownlint-disable-line MD013 -->
         await ws.send_media({

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -257,9 +257,9 @@ logic.
     connection is established and routed to this resource. `req` is the standard
     Falcon `Request` object associated with the initial HTTP upgrade request,
     and `ws` is a **`WebSocketLike` connection**. The protocol defines the
-    minimal `send`, `accept`, and `close` methods needed by the resource.
+    minimal `send_media`, `accept`, and `close` methods needed by the resource.
     `params` will contain any
-    path parameters from the route. The method should return `True` to accept
+    path parameters from the route. It returns `True` to accept
     the connection or `False` to reject it. If `False` is returned, the library
     will handle sending an appropriate closing handshake (e.g., HTTP 403 or a
     custom code if supported by an extension like WebSocket Denial Response 12).

--- a/falcon_pachinko/__init__.py
+++ b/falcon_pachinko/__init__.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from .resource import WebSocketResource, handles_message
+from .resource import WebSocketLike, WebSocketResource, handles_message
 from .websocket import WebSocketConnectionManager, install
 
 __all__ = (
     "WebSocketConnectionManager",
+    "WebSocketLike",
     "WebSocketResource",
     "handles_message",
     "install",

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -8,12 +8,25 @@ import typing
 import msgspec
 
 
+class WebSocketLike(typing.Protocol):
+    """Minimal interface for WebSocket connections."""
+
+    async def accept(self, subprotocol: str | None = None) -> None:
+        """Accept the WebSocket handshake."""
+
+    async def close(self, code: int = 1000) -> None:
+        """Close the WebSocket connection."""
+
+    async def send_media(self, data: typing.Any) -> None:
+        """Send structured data over the connection."""
+
+
 class _Envelope(msgspec.Struct, frozen=True):
     type: str
     payload: typing.Any | None = None
 
 
-Handler = cabc.Callable[[typing.Any, typing.Any, typing.Any], cabc.Awaitable[None]]
+Handler = cabc.Callable[[typing.Any, WebSocketLike, typing.Any], cabc.Awaitable[None]]
 
 
 def _select_payload_param(
@@ -155,7 +168,7 @@ class WebSocketResource:
                 handlers[msg_type] = (new_handler, payload_type)
 
     async def on_connect(
-        self, req: typing.Any, ws: typing.Any, **params: typing.Any
+        self, req: typing.Any, ws: WebSocketLike, **params: typing.Any
     ) -> bool:
         """
         Called after the WebSocket handshake is complete to decide whether the
@@ -171,7 +184,7 @@ class WebSocketResource:
         """
         return True
 
-    async def on_disconnect(self, ws: typing.Any, close_code: int) -> None:
+    async def on_disconnect(self, ws: WebSocketLike, close_code: int) -> None:
         """
         Handles cleanup or custom logic when the WebSocket connection is closed.
 
@@ -180,7 +193,7 @@ class WebSocketResource:
             close_code: The close code indicating the reason for disconnection.
         """
 
-    async def on_message(self, ws: typing.Any, message: str | bytes) -> None:
+    async def on_message(self, ws: WebSocketLike, message: str | bytes) -> None:
         """
         Handles incoming WebSocket messages that do not match any registered handler.
 
@@ -201,7 +214,7 @@ class WebSocketResource:
         """
         cls.handlers[message_type] = (handler, payload_type)
 
-    async def dispatch(self, ws: typing.Any, raw: str | bytes) -> None:
+    async def dispatch(self, ws: WebSocketLike, raw: str | bytes) -> None:
         """
         Processes an incoming raw WebSocket message and dispatches it to the
         appropriate handler.

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -5,6 +5,8 @@ import functools
 import inspect
 import typing
 
+if typing.TYPE_CHECKING:
+    import falcon
 import msgspec
 
 
@@ -170,7 +172,7 @@ class WebSocketResource:
                 handlers[msg_type] = (new_handler, payload_type)
 
     async def on_connect(
-        self, req: typing.Any, ws: WebSocketLike, **params: typing.Any
+        self, req: falcon.Request, ws: WebSocketLike, **params: typing.Any
     ) -> bool:
         """
         Called after the WebSocket handshake is complete to decide whether the

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -26,6 +26,8 @@ class _Envelope(msgspec.Struct, frozen=True):
     payload: typing.Any | None = None
 
 
+# Handlers accept ``self``, a ``WebSocketLike`` connection, and a decoded
+# payload. The return value is ignored.
 Handler = cabc.Callable[[typing.Any, WebSocketLike, typing.Any], cabc.Awaitable[None]]
 
 

--- a/falcon_pachinko/unittests/helpers.py
+++ b/falcon_pachinko/unittests/helpers.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import typing
+
+
+class DummyWS:
+    async def accept(self, subprotocol: str | None = None) -> None:  # pragma: no cover
+        pass
+
+    async def close(self, code: int = 1000) -> None:  # pragma: no cover
+        pass
+
+    async def send_media(self, data: typing.Any) -> None:  # pragma: no cover
+        pass

--- a/falcon_pachinko/unittests/test_handles_message.py
+++ b/falcon_pachinko/unittests/test_handles_message.py
@@ -1,8 +1,21 @@
+"""Tests for the @handles_message decorator functionality.
+
+This module contains comprehensive tests for the @handles_message decorator,
+which is used to register message handlers for WebSocket resources. The tests
+cover various scenarios including:
+
+- Basic decorator functionality and message dispatching
+- Error handling for duplicate handlers and invalid signatures
+- Inheritance behavior with parent and child resources
+- Method overriding with and without decorators
+- Type annotation handling for payload parameters
+"""
 from __future__ import annotations
 
 import typing
 
 import msgspec
+import msgspec.json
 import pytest
 
 from falcon_pachinko import WebSocketLike, WebSocketResource, handles_message
@@ -10,20 +23,37 @@ from falcon_pachinko.unittests.helpers import DummyWS
 
 
 class PingPayload(msgspec.Struct):
+    """A simple message payload structure for testing ping messages."""
     text: str
 
 
 class DecoratedResource(WebSocketResource):
+    """A WebSocket resource with a decorated message handler for testing basic functionality."""
+
     def __init__(self) -> None:
+        """Initialize the resource with an empty list to track seen messages."""
         self.seen: list[str] = []
 
     @handles_message("ping")
     async def handle_ping(self, ws: WebSocketLike, payload: PingPayload) -> None:
+        """Handle ping messages by recording the text payload.
+
+        Args:
+            ws: The WebSocket connection
+            payload: The ping message payload containing text
+        """
         self.seen.append(payload.text)
 
 
 @pytest.mark.asyncio()
 async def test_decorator_registers_handler() -> None:
+    """Test that the @handles_message decorator properly registers a message handler.
+
+    This test verifies that:
+    1. A decorated method is registered as a handler for the specified message type
+    2. The handler is correctly invoked when a matching message is dispatched
+    3. The payload is properly deserialized and passed to the handler
+    """
     r = DecoratedResource()
     raw = msgspec.json.encode({"type": "ping", "payload": {"text": "hi"}})
     await r.dispatch(DummyWS(), raw)
@@ -31,6 +61,11 @@ async def test_decorator_registers_handler() -> None:
 
 
 def test_duplicate_handler_raises() -> None:
+    """Test that registering duplicate handlers for the same message type raises an error.
+
+    This test ensures that attempting to register multiple handlers for the same
+    message type results in a RuntimeError with an appropriate error message.
+    """
     with pytest.raises(RuntimeError, match="Duplicate handler"):
 
         class BadResource(WebSocketResource):  # pyright: ignore[reportUnusedClass]
@@ -42,6 +77,11 @@ def test_duplicate_handler_raises() -> None:
 
 
 def test_missing_payload_param_raises() -> None:
+    """Test that handlers missing the required payload parameter raise a TypeError.
+
+    This test verifies that the decorator validates handler method signatures
+    and raises an error when the required payload parameter is missing.
+    """
     with pytest.raises(TypeError):
 
         class BadSig(WebSocketResource):  # pyright: ignore[reportUnusedClass]
@@ -50,31 +90,84 @@ def test_missing_payload_param_raises() -> None:
 
 
 class ParentResource(WebSocketResource):
+    """A parent WebSocket resource class with a decorated message handler.
+
+    This class is used to test inheritance behavior of message handlers.
+    """
+
     @handles_message("parent")
-    async def parent(self, ws: WebSocketLike, payload: typing.Any) -> None: ...
+    async def parent(self, ws: WebSocketLike, payload: typing.Any) -> None:
+        """Handle parent messages.
+
+        Args:
+            ws: The WebSocket connection
+            payload: The message payload
+        """
+        ...
 
 
 class ChildResource(ParentResource):
+    """A child WebSocket resource that inherits from ParentResource.
+
+    This class tests that:
+    1. Child classes inherit parent message handlers
+    2. Child classes can define their own additional handlers
+    3. Child classes can override parent handlers without decoration
+    """
+
     def __init__(self) -> None:
+        """Initialize the child resource with a list to track invoked handlers."""
         self.invoked: list[str] = []
 
     @handles_message("child")
     async def child(self, ws: WebSocketLike, payload: typing.Any) -> None:
+        """Handle child-specific messages.
+
+        Args:
+            ws: The WebSocket connection
+            payload: The message payload
+        """
         self.invoked.append("child")
 
     async def parent(self, ws: WebSocketLike, payload: typing.Any) -> None:  # pyright: ignore[reportIncompatibleVariableOverride]
+        """Override the parent handler to record invocation.
+
+        Args:
+            ws: The WebSocket connection
+            payload: The message payload
+        """
         # override to record
         self.invoked.append("parent")
 
 
 class DecoratedOverride(ParentResource):
+    """A resource that overrides a parent handler using the decorator.
+
+    This class tests that child classes can override parent handlers
+    by re-decorating methods with the same message type.
+    """
+
     @handles_message("parent")
     async def parent(self, ws: WebSocketLike, payload: typing.Any) -> None:
+        """Override the parent handler with decoration.
+
+        Args:
+            ws: The WebSocket connection
+            payload: The message payload
+        """
         self.invoked = "decorated"
 
 
 @pytest.mark.asyncio()
 async def test_handlers_inherited() -> None:
+    """Test that child classes inherit message handlers from parent classes.
+
+    This test verifies that:
+    1. Child classes inherit decorated handlers from parent classes
+    2. Child classes can define their own additional handlers
+    3. Both inherited and child-specific handlers work correctly
+    4. Method overrides without decoration still work as handlers
+    """
     r = ChildResource()
     await r.dispatch(DummyWS(), msgspec.json.encode({"type": "parent"}))
     await r.dispatch(DummyWS(), msgspec.json.encode({"type": "child"}))
@@ -83,19 +176,40 @@ async def test_handlers_inherited() -> None:
 
 @pytest.mark.asyncio()
 async def test_decorated_override() -> None:
+    """Test that child classes can override parent handlers using decoration.
+
+    This test verifies that when a child class re-decorates a method with
+    the same message type as a parent handler, the child's handler takes
+    precedence over the parent's handler.
+    """
     r = DecoratedOverride()
     await r.dispatch(DummyWS(), msgspec.json.encode({"type": "parent"}))
     assert r.invoked == "decorated"
 
 
 def test_unresolved_annotation_is_ignored() -> None:
+    """Test that unresolved type annotations are handled gracefully.
+
+    This test verifies that when a handler method has a payload parameter
+    with a type annotation that cannot be resolved at runtime, the system
+    gracefully handles this by setting the payload type to None in the
+    handler registry, rather than raising an error.
+    """
     class UnknownAnnoResource(WebSocketResource):
+        """A resource with an unresolved payload type annotation."""
+
         @handles_message("unknown")
         async def handler(
             self,
             ws: WebSocketLike,
-            payload: "UnknownType",  # noqa: UP037,F821  # pyright: ignore[reportUnknownParameterType,reportUndefinedVariable]
-        ) -> None:  # pyright: ignore[reportUnknownVariableType]
+            payload: "UnknownPayload", # type: ignore  # noqa: F821, UP037
+        ) -> None:
+            """Handle messages with unresolved payload type.
+
+            Args:
+                ws: The WebSocket connection
+                payload: The message payload with unresolved type
+            """
             ...
 
     assert UnknownAnnoResource.handlers["unknown"][1] is None

--- a/falcon_pachinko/unittests/test_handles_message.py
+++ b/falcon_pachinko/unittests/test_handles_message.py
@@ -7,9 +7,21 @@ import pytest
 
 from falcon_pachinko import WebSocketResource, handles_message
 
+if typing.TYPE_CHECKING:
+    from falcon_pachinko.resource import WebSocketLike
+else:  # pragma: no cover - used for runtime type hints
+    WebSocketLike = typing.Any
+
 
 class DummyWS:
-    pass
+    async def accept(self, subprotocol: str | None = None) -> None:
+        pass
+
+    async def close(self, code: int = 1000) -> None:
+        pass
+
+    async def send_media(self, data: typing.Any) -> None:
+        pass
 
 
 class PingPayload(msgspec.Struct):
@@ -21,7 +33,7 @@ class DecoratedResource(WebSocketResource):
         self.seen: list[str] = []
 
     @handles_message("ping")
-    async def handle_ping(self, ws: typing.Any, payload: PingPayload) -> None:
+    async def handle_ping(self, ws: WebSocketLike, payload: PingPayload) -> None:
         self.seen.append(payload.text)
 
 
@@ -38,10 +50,10 @@ def test_duplicate_handler_raises() -> None:
 
         class BadResource(WebSocketResource):  # pyright: ignore[reportUnusedClass]
             @handles_message("dup")
-            async def h1(self, ws: typing.Any, payload: typing.Any) -> None: ...
+            async def h1(self, ws: WebSocketLike, payload: typing.Any) -> None: ...
 
             @handles_message("dup")
-            async def h2(self, ws: typing.Any, payload: typing.Any) -> None: ...
+            async def h2(self, ws: WebSocketLike, payload: typing.Any) -> None: ...
 
 
 def test_missing_payload_param_raises() -> None:
@@ -49,12 +61,12 @@ def test_missing_payload_param_raises() -> None:
 
         class BadSig(WebSocketResource):  # pyright: ignore[reportUnusedClass]
             @handles_message("oops")  # pyright: ignore[reportArgumentType]
-            async def bad(self, ws: typing.Any) -> None: ...
+            async def bad(self, ws: WebSocketLike) -> None: ...
 
 
 class ParentResource(WebSocketResource):
     @handles_message("parent")
-    async def parent(self, ws: typing.Any, payload: typing.Any) -> None: ...
+    async def parent(self, ws: WebSocketLike, payload: typing.Any) -> None: ...
 
 
 class ChildResource(ParentResource):
@@ -62,17 +74,17 @@ class ChildResource(ParentResource):
         self.invoked: list[str] = []
 
     @handles_message("child")
-    async def child(self, ws: typing.Any, payload: typing.Any) -> None:
+    async def child(self, ws: WebSocketLike, payload: typing.Any) -> None:
         self.invoked.append("child")
 
-    async def parent(self, ws: typing.Any, payload: typing.Any) -> None:  # pyright: ignore[reportIncompatibleVariableOverride]
+    async def parent(self, ws: WebSocketLike, payload: typing.Any) -> None:  # pyright: ignore[reportIncompatibleVariableOverride]
         # override to record
         self.invoked.append("parent")
 
 
 class DecoratedOverride(ParentResource):
     @handles_message("parent")
-    async def parent(self, ws: typing.Any, payload: typing.Any) -> None:
+    async def parent(self, ws: WebSocketLike, payload: typing.Any) -> None:
         self.invoked = "decorated"
 
 
@@ -96,7 +108,7 @@ def test_unresolved_annotation_is_ignored() -> None:
         @handles_message("unknown")
         async def handler(
             self,
-            ws: typing.Any,
+            ws: WebSocketLike,
             payload: "UnknownType",  # noqa: UP037,F821  # pyright: ignore[reportUnknownParameterType,reportUndefinedVariable]
         ) -> None:  # pyright: ignore[reportUnknownVariableType]
             ...

--- a/falcon_pachinko/unittests/test_handles_message.py
+++ b/falcon_pachinko/unittests/test_handles_message.py
@@ -5,23 +5,8 @@ import typing
 import msgspec
 import pytest
 
-from falcon_pachinko import WebSocketResource, handles_message
-
-if typing.TYPE_CHECKING:
-    from falcon_pachinko.resource import WebSocketLike
-else:  # pragma: no cover - used for runtime type hints
-    WebSocketLike = typing.Any
-
-
-class DummyWS:
-    async def accept(self, subprotocol: str | None = None) -> None:
-        pass
-
-    async def close(self, code: int = 1000) -> None:
-        pass
-
-    async def send_media(self, data: typing.Any) -> None:
-        pass
+from falcon_pachinko import WebSocketLike, WebSocketResource, handles_message
+from falcon_pachinko.unittests.helpers import DummyWS
 
 
 class PingPayload(msgspec.Struct):

--- a/falcon_pachinko/unittests/test_websocket_resource.py
+++ b/falcon_pachinko/unittests/test_websocket_resource.py
@@ -5,22 +5,12 @@ import typing
 import msgspec
 import pytest
 
-from falcon_pachinko.resource import WebSocketLike, WebSocketResource
+from falcon_pachinko import WebSocketLike, WebSocketResource
+from falcon_pachinko.unittests.helpers import DummyWS
 
 
 class EchoPayload(msgspec.Struct):
     text: str
-
-
-class DummyWS:
-    async def accept(self, subprotocol: str | None = None) -> None:
-        pass
-
-    async def close(self, code: int = 1000) -> None:
-        pass
-
-    async def send_media(self, data: typing.Any) -> None:
-        pass
 
 
 class EchoResource(WebSocketResource):

--- a/falcon_pachinko/unittests/test_websocket_resource.py
+++ b/falcon_pachinko/unittests/test_websocket_resource.py
@@ -5,7 +5,7 @@ import typing
 import msgspec
 import pytest
 
-from falcon_pachinko.resource import WebSocketResource
+from falcon_pachinko.resource import WebSocketLike, WebSocketResource
 
 
 class EchoPayload(msgspec.Struct):
@@ -13,7 +13,14 @@ class EchoPayload(msgspec.Struct):
 
 
 class DummyWS:
-    pass
+    async def accept(self, subprotocol: str | None = None) -> None:
+        pass
+
+    async def close(self, code: int = 1000) -> None:
+        pass
+
+    async def send_media(self, data: typing.Any) -> None:
+        pass
 
 
 class EchoResource(WebSocketResource):
@@ -26,7 +33,7 @@ class EchoResource(WebSocketResource):
         self.seen: list[typing.Any] = []
         self.fallback: list[typing.Any] = []
 
-    async def on_message(self, ws: typing.Any, message: str | bytes) -> None:
+    async def on_message(self, ws: WebSocketLike, message: str | bytes) -> None:
         """
         Handles messages that do not match any registered handler by appending them to the fallback list.
 
@@ -38,7 +45,7 @@ class EchoResource(WebSocketResource):
 
 
 async def echo_handler(
-    self: EchoResource, ws: typing.Any, payload: EchoPayload
+    self: EchoResource, ws: WebSocketLike, payload: EchoPayload
 ) -> None:
     """
     Handles an "echo" message by recording the payload text.
@@ -58,7 +65,7 @@ class RawResource(WebSocketResource):
         """
         self.received: list[typing.Any] = []
 
-    async def on_message(self, ws: typing.Any, message: str | bytes) -> None:
+    async def on_message(self, ws: WebSocketLike, message: str | bytes) -> None:
         """
         Handles incoming messages by appending them to the received list.
 
@@ -67,7 +74,9 @@ class RawResource(WebSocketResource):
         self.received.append(message)
 
 
-async def raw_handler(self: RawResource, ws: typing.Any, payload: typing.Any) -> None:
+async def raw_handler(
+    self: RawResource, ws: WebSocketLike, payload: typing.Any
+) -> None:
     """
     Handles incoming messages of type "raw" by appending the payload to the resource's received list.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ requires-python = ">=3.10"
 license = { text = "ISC" }
 dependencies = ["msgspec>=0.18", "falcon"]
 
-[project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio", "ruff", "pyright"]
+[dependency-groups]
+dev = ["pytest", "pytest-asyncio", "ruff", "pyright[nodejs]"]
 
 [tool.pyright]
 pythonVersion = "3.13"


### PR DESCRIPTION
## Summary
- specify WebSocketLike protocol
- use WebSocketLike in WebSocketResource
- update tests for new protocol

## Testing
- `ruff format falcon_pachinko/resource.py falcon_pachinko/unittests/test_handles_message.py falcon_pachinko/unittests/test_websocket_resource.py`
- `ruff check falcon_pachinko/resource.py falcon_pachinko/unittests/test_websocket_resource.py falcon_pachinko/unittests/test_handles_message.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca22521008322b9f56bcb32b94e56

## Summary by Sourcery

Introduce a WebSocketLike protocol as a minimal interface for WebSocket connections, refactor resource and handler APIs to use it, and update documentation and tests accordingly.

New Features:
- Define a WebSocketLike protocol to abstract WebSocket connections.

Enhancements:
- Refactor WebSocketResource methods and handlers to use WebSocketLike instead of falcon.asgi.WebSocket or untyped parameters.
- Export WebSocketLike in the package’s public API.
- Add a DummyWS helper implementing WebSocketLike for unit tests.

Documentation:
- Update design documentation and code examples to reference the WebSocketLike protocol.

Tests:
- Adapt existing WebSocketResource and handles_message tests to use WebSocketLike and the new DummyWS helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a standardized WebSocket-like interface to improve consistency and clarity in WebSocket connection handling.
  * Updated method signatures across core and test components to use the new WebSocket interface.
  * Enhanced test utilities with asynchronous stubs simulating WebSocket behavior.
* **Documentation**
  * Updated documentation and examples to reflect the new WebSocket interface, improving abstraction and clarity for users.
* **Chores**
  * Updated project configuration to reorganize development dependencies and improve tooling setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->