### PR TITLE
Document composable WebSocket router

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,3 +1,4 @@
+
 # Falcon-Pachinko Roadmap
 
 This roadmap outlines the implementation tasks for the Falcon-Pachinko
@@ -56,3 +57,11 @@ after formatting.
    - [ ] Make the connection manager pluggable for distributed deployments.
    - [ ] Consider automatic AsyncAPI stub generation based on resources and
      handlers.
+
+8. **Composable Routing Addendum** (lines 936-1000)
+   - [ ] Implement `WebSocketRouter` with `add_route` and mounting via `app.ws_app`.
+   - [ ] Support `add_subroute` for nested resources and context passing.
+   - [ ] Use `msgspec` tagged unions for automatic dispatch to `on_<tag>` handlers.
+   - [ ] Provide global and per-resource hooks for connection and message events.
+   - [ ] Introduce a dependency injection mechanism for resource construction.
+   - [ ] Expand tests to cover nested routing and schema-driven dispatch.


### PR DESCRIPTION
## Summary
- add an addendum describing a `WebSocketRouter` with nested routing
- extend roadmap with tasks for composable router work

## Testing
- `markdownlint docs/falcon-websocket-extension-design.md`
- `markdownlint docs/roadmap.md`
- `nixie docs/falcon-websocket-extension-design.md`


------
https://chatgpt.com/codex/tasks/task_e_68606b90bc24832295df38fc34e162fa

## Summary by Sourcery

Document the composable WebSocket router design and extend the roadmap with tasks for its implementation.

Documentation:
- Add an addendum to the WebSocket extension design guide outlining the composable routing architecture, including WebSocketRouter, nested resources, schema-driven dispatch, hooks, dependency injection, and error handling.

Chores:
- Update the project roadmap with implementation tasks for the composable WebSocket router, including route addition, nested subroutes, message dispatch, hooks, dependency injection, and testing coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a detailed section describing composable routing and schema-driven dispatch for WebSocket resources, including routing architecture, message handling, lifecycle hooks, and dependency injection.
  * Updated the roadmap with planned enhancements for WebSocket routing, nested resources, message dispatching, lifecycle hooks, and expanded test coverage.
  * Minor formatting improvements for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->