### PR TITLE
Format Markdown files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,11 +130,11 @@ When implementing changes, adhere to the following testing procedures:
   the heuristics above.
 - **Separate Atomic Refactors:** If refactoring is deemed necessary:
   - Perform the refactoring as a **separate, atomic commit** *after* the
-    functional change commit.
+    functional-change commit.
   - Ensure the refactoring adheres to the testing guidelines (behavioral tests
     pass before and after, unit tests added for new units).
   - Ensure the refactoring commit itself passes all quality gates.
 
 ## Python Development Guidelines
 
-See \`.rules/python-\*.mdc for guidance on Python development.
+See \`.rules/python-\*.mdc\` for guidance on Python development.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,89 +2,139 @@
 
 ## Code Style and Structure
 
-* **Code is for humans.** Write your code with clarity and empathy—assume a tired teammate will need to debug it at 3 a.m.
-* **Comment *why*, not *what*.** Explain assumptions, edge cases, trade-offs, or complexity. Don't echo the obvious.
-* **Clarity over cleverness.** Be concise, but favour explicit over terse or obscure idioms. Prefer code that's easy to follow.
-* **Use functions and composition.** Avoid repetition by extracting reusable logic. Prefer generators or comprehensions to imperative repetition when readable.
-* **Name things precisely.** Use clear, descriptive variable and function names. For booleans, prefer names with `is`, `has`, or `should`.
-* **Structure logically.** Each file should encapsulate a coherent module. Group related code (e.g., models + utilities + fixtures) close together.
-* **Group by feature, not layer.** Colocate views, logic, fixtures, and helpers related to a domain concept rather than splitting by type.
+- **Code is for humans.** Write your code with clarity and empathy—assume a
+  tired teammate will need to debug it at 3 a.m.
+- **Comment *why*, not *what*.** Explain assumptions, edge cases, trade-offs, or
+  complexity. Don't echo the obvious.
+- **Clarity over cleverness.** Be concise, but favour explicit over terse or
+  obscure idioms. Prefer code that's easy to follow.
+- **Use functions and composition.** Avoid repetition by extracting reusable
+  logic. Prefer generators or comprehensions to imperative repetition when
+  readable.
+- **Name things precisely.** Use clear, descriptive variable and function names.
+  For booleans, prefer names with `is`, `has`, or `should`.
+- **Structure logically.** Each file should encapsulate a coherent module. Group
+  related code (e.g., models + utilities + fixtures) close together.
+- **Group by feature, not layer.** Colocate views, logic, fixtures, and helpers
+  related to a domain concept rather than splitting by type.
 
 ## Documentation Maintenance
 
-*   **Reference:** Use the markdown files within the `docs/` directory as a knowledge base and source of truth for project requirements, dependency choices, and architectural decisions.
-*   **Update:** When new decisions are made, requirements change, libraries are added/removed, or architectural patterns evolve, **proactively update** the relevant file(s) in the `docs/` directory to reflect the latest state. Ensure the documentation remains accurate and current.
+- **Reference:** Use the markdown files within the `docs/` directory as a
+  knowledge base and source of truth for project requirements, dependency
+  choices, and architectural decisions.
+- **Update:** When new decisions are made, requirements change, libraries are
+  added/removed, or architectural patterns evolve, **proactively update** the
+  relevant file(s) in the `docs/` directory to reflect the latest state. Ensure
+  the documentation remains accurate and current.
 
 ## Guidelines for Code Changes & Testing
 
 When implementing changes, adhere to the following testing procedures:
 
-* **New Functionality:**
-  * Implement unit tests covering all new code units (functions, components, classes). Implement tests **before** implementing the unit.
-  * Implement behavioral tests that verify the end-to-end behavior of the new feature from a user interaction perspective.
-  * Ensure both unit and behavioral tests pass before considering the functionality complete.
-* **Bug Fixes:**
-  * Before fixing the bug, write a new test (unit or behavioral, whichever is most appropriate) that specifically targets and reproduces the bug. This test should initially fail.
-  * Implement the bug fix.
-  * Verify that the new test now passes, along with all existing tests.
-* **Modifying Existing Functionality:**
-  * Identify the existing behavioral and unit tests relevant to the functionality being changed.
-  * **First, modify the tests** to reflect the new requirements or behavior.
-  * Run the tests; they should now fail.
-  * Implement the code changes to the functionality.
-  * Verify that the modified tests (and all other existing tests) now pass.
-* **Refactoring:**
-  * Identify or create a behavioral test that covers the functionality being refactored. Ensure this test passes **before** starting the refactor.
-  * Perform the refactoring (e.g., extracting logic into a new unit).
-  * If new units are created (e.g., a new function or component), add unit tests for these extracted units.
-  * After the refactor, ensure the original behavioral test **still passes** without modification. Also ensure any new unit tests pass.
+- **New Functionality:**
+  - Implement unit tests covering all new code units (functions, components,
+    classes). Implement tests **before** implementing the unit.
+  - Implement behavioral tests that verify the end-to-end behavior of the new
+    feature from a user interaction perspective.
+  - Ensure both unit and behavioral tests pass before considering the
+    functionality complete.
+- **Bug Fixes:**
+  - Before fixing the bug, write a new test (unit or behavioral, whichever is
+    most appropriate) that specifically targets and reproduces the bug. This
+    test should initially fail.
+  - Implement the bug fix.
+  - Verify that the new test now passes, along with all existing tests.
+- **Modifying Existing Functionality:**
+  - Identify the existing behavioral and unit tests relevant to the
+    functionality being changed.
+  - **First, modify the tests** to reflect the new requirements or behavior.
+  - Run the tests; they should now fail.
+  - Implement the code changes to the functionality.
+  - Verify that the modified tests (and all other existing tests) now pass.
+- **Refactoring:**
+  - Identify or create a behavioral test that covers the functionality being
+    refactored. Ensure this test passes **before** starting the refactor.
+  - Perform the refactoring (e.g., extracting logic into a new unit).
+  - If new units are created (e.g., a new function or component), add unit tests
+    for these extracted units.
+  - After the refactor, ensure the original behavioral test **still passes**
+    without modification. Also ensure any new unit tests pass.
 
 ## Change Quality & Committing
 
-* **Atomicity:** Aim for small, focused, atomic changes. Each change (and subsequent commit) should represent a single logical unit of work.
-* **Quality Gates:** Before considering a change complete or proposing a commit, ensure it meets the following criteria:
-  * For Python files:
-    * **Testing:** Passes all relevant unit and behavioral tests according to the guidelines above.
-    * **Linting:** Passes lint checks (`ruff check`).
-    * **Formatting:** Adheres to formatting standards (`ruff format` and `ruff check --select I --fix .`).
-    * **Typechecking:** Passes type checking (`pyright` and `ty check`).
-  * For TypeScript files:
-    * **Testing:** Passes all relevant unit and behavioral tests according to the guidelines above.
-    * **Linting:** Passes lint checks (`biome check .`).
-    * **Formatting:** Adheres to formatting standards (`biome check --apply .`).
-    * **TypeScript Compilation:** Compiles successfully without TypeScript errors (`tsc --noEmit`).
-  
-  * For Markdown files (`.md` only):
-    * **Linting:** Passes lint checks (`markdownlint filename.md`).
-    * **Mermaid diagrams:** Passes validation using nixie (`nixie filename.md`)
-* **Committing:**
-  * Only changes that meet all the quality gates above should be committed.
-  * Write clear, descriptive commit messages summarizing the change, following these formatting guidelines:
-    * **Imperative Mood:** Use the imperative mood in the subject line (e.g., "Fix bug", "Add feature" instead of "Fixed bug", "Added feature").
-    * **Subject Line:** The first line should be a concise summary of the change (ideally 50 characters or less).
-    * **Body:** Separate the subject from the body with a blank line. Subsequent lines should explain the *what* and *why* of the change in more detail, including rationale, goals, and scope. Wrap the body at 72 characters.
-    * **Formatting:** Use Markdown for any formatted text (like bullet points or code snippets) within the commit message body.
-  * Do not commit changes that fail any of the quality gates.
+- **Atomicity:** Aim for small, focused, atomic changes. Each change (and
+  subsequent commit) should represent a single logical unit of work.
+- **Quality Gates:** Before considering a change complete or proposing a commit,
+  ensure it meets the following criteria:
+  - For Python files:
+
+    - **Testing:** Passes all relevant unit and behavioral tests according to
+      the guidelines above.
+    - **Linting:** Passes lint checks (`ruff check`).
+    - **Formatting:** Adheres to formatting standards (`ruff format` and
+      `ruff check --select I --fix .`).
+    - **Typechecking:** Passes type checking (`pyright` and `ty check`).
+
+  - For TypeScript files:
+
+    - **Testing:** Passes all relevant unit and behavioral tests according to
+      the guidelines above.
+    - **Linting:** Passes lint checks (`biome check .`).
+    - **Formatting:** Adheres to formatting standards (`biome check --apply .`).
+    - **TypeScript Compilation:** Compiles successfully without TypeScript
+      errors (`tsc --noEmit`).
+
+  - For Markdown files (`.md` only):
+
+    - **Linting:** Passes lint checks (`markdownlint filename.md`).
+    - **Mermaid diagrams:** Passes validation using nixie (`nixie filename.md`)
+- **Committing:**
+  - Only changes that meet all the quality gates above should be committed.
+  - Write clear, descriptive commit messages summarizing the change, following
+    these formatting guidelines:
+    - **Imperative Mood:** Use the imperative mood in the subject line (e.g.,
+      "Fix bug", "Add feature" instead of "Fixed bug", "Added feature").
+    - **Subject Line:** The first line should be a concise summary of the change
+      (ideally 50 characters or less).
+    - **Body:** Separate the subject from the body with a blank line. Subsequent
+      lines should explain the *what* and *why* of the change in more detail,
+      including rationale, goals, and scope. Wrap the body at 72 characters.
+    - **Formatting:** Use Markdown for any formatted text (like bullet points or
+      code snippets) within the commit message body.
+  - Do not commit changes that fail any of the quality gates.
 
 ## Refactoring Heuristics & Workflow
 
-* **Recognizing Refactoring Needs:** Regularly assess the codebase for potential refactoring opportunities. Consider refactoring when you observe:
-  * **Long Methods/Functions:** Functions or methods that are excessively long or try to do too many things.
-  * **Duplicated Code:** Identical or very similar code blocks appearing in multiple places.
-  * **Complex Conditionals:** Deeply nested or overly complex `if`/`else` or `switch` statements (high cyclomatic complexity).
-  * **Large Code Blocks for Single Values:** Significant chunks of logic dedicated solely to calculating or deriving a single value.
-  * **Primitive Obsession / Data Clumps:** Groups of simple variables (strings, numbers, booleans) that are frequently passed around together, often indicating a missing class or object structure.
-  * **Excessive Parameters:** Functions or methods requiring a very long list of parameters.
-  * **Feature Envy:** Methods that seem more interested in the data of another class/object than their own.
-  * **Shotgun Surgery:** A single change requiring small modifications in many different classes or functions.
-* **Post-Commit Review:** After committing a functional change or bug fix (that meets all quality gates), review the changed code and surrounding areas using the heuristics above.
-* **Separate Atomic Refactors:** If refactoring is deemed necessary:
-  * Perform the refactoring as a **separate, atomic commit** *after* the functional change commit.
-  * Ensure the refactoring adheres to the testing guidelines (behavioral tests pass before and after, unit tests added for new units).
-  * Ensure the refactoring commit itself passes all quality gates.
-
-
+- **Recognizing Refactoring Needs:** Regularly assess the codebase for potential
+  refactoring opportunities. Consider refactoring when you observe:
+  - **Long Methods/Functions:** Functions or methods that are excessively long
+    or try to do too many things.
+  - **Duplicated Code:** Identical or very similar code blocks appearing in
+    multiple places.
+  - **Complex Conditionals:** Deeply nested or overly complex `if`/`else` or
+    `switch` statements (high cyclomatic complexity).
+  - **Large Code Blocks for Single Values:** Significant chunks of logic
+    dedicated solely to calculating or deriving a single value.
+  - **Primitive Obsession / Data Clumps:** Groups of simple variables (strings,
+    numbers, booleans) that are frequently passed around together, often
+    indicating a missing class or object structure.
+  - **Excessive Parameters:** Functions or methods requiring a very long list of
+    parameters.
+  - **Feature Envy:** Methods that seem more interested in the data of another
+    class/object than their own.
+  - **Shotgun Surgery:** A single change requiring small modifications in many
+    different classes or functions.
+- **Post-Commit Review:** After committing a functional change or bug fix (that
+  meets all quality gates), review the changed code and surrounding areas using
+  the heuristics above.
+- **Separate Atomic Refactors:** If refactoring is deemed necessary:
+  - Perform the refactoring as a **separate, atomic commit** *after* the
+    functional change commit.
+  - Ensure the refactoring adheres to the testing guidelines (behavioral tests
+    pass before and after, unit tests added for new units).
+  - Ensure the refactoring commit itself passes all quality gates.
 
 ## Python Development Guidelines
 
-See `.rules/python-*.mdc for guidance on Python development.
+See \`.rules/python-\*.mdc for guidance on Python development.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ When implementing changes, adhere to the following testing procedures:
     - **Imperative Mood:** Use the imperative mood in the subject line (e.g.,
       "Fix bug", "Add feature" instead of "Fixed bug", "Added feature").
     - **Subject Line:** The first line should be a concise summary of the change
-      (ideally 50 characters or less).
+      (ideally 50 characters or fewer).
     - **Body:** Separate the subject from the body with a blank line. Subsequent
       lines should explain the *what* and *why* of the change in more detail,
       including rationale, goals, and scope. Wrap the body at 72 characters.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ for the full design rationale.
 - `app.add_websocket_route()` maps WebSocket paths to `WebSocketResource`
   classes, mirroring Falcon's HTTP routing. Initialization parameters can be
   supplied, so one resource class supports multiple configurations.
-- `WebSocketResource` provides `on_connect`, `on_disconnect`, and
-  `on_message` lifecycle hooks.
+- `WebSocketResource` provides `on_connect`, `on_disconnect`, and `on_message`
+  lifecycle hooks.
 - Message payloads are parsed into `msgspec.Struct` classes for speed and type
   safety.
 - `@handles_message("type")` dispatches incoming JSON messages to specific
@@ -39,24 +39,23 @@ async def handle_new_chat_message(self, ws, payload):
 
 ## Roadmap
 
-Implementation tasks are tracked in [docs/roadmap.md](docs/roadmap.md).
-See the [Release Workflow documentation](docs/release-workflow.md) for release
-details.
+Implementation tasks are tracked in [docs/roadmap.md](docs/roadmap.md). See the
+[Release Workflow documentation](docs/release-workflow.md) for release details.
 
 ## Examples
 
-An end-to-end demonstration lives under
-`examples/random_status`. It shows how to:
+An end-to-end demonstration lives under `examples/random_status`. It shows how
+to:
 
 - expose an HTTP endpoint returning the current status
-- handle a WebSocket message that updates that status in an
-  SQLite database using `aiosqlite`
+- handle a WebSocket message that updates that status in an SQLite database
+  using `aiosqlite`
 - send a periodic "random" message from a background task.
 
-Run `server.py` with Uvicorn and connect using the provided
-`client.py` to observe the interaction.
+Run `server.py` with Uvicorn and connect using the provided `client.py` to
+observe the interaction.
 
 ## License
 
-This project is licensed under the terms of the ISC license.
-See [LICENSE](LICENSE) for details.
+This project is licensed under the terms of the ISC license. See
+[LICENSE](LICENSE) for details.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,9 +1,9 @@
 # Release Workflow
 
-The release workflow builds and publishes a pure Python wheel.
-Binary wheels for specific architectures are no longer produced. The
-cross-platform `build` job in `.github/workflows/release.yml` was disabled to
-avoid unnecessary maintenance, since the project contains no C or Rust code.
+The release workflow builds and publishes a pure Python wheel. Binary wheels for
+specific architectures are no longer produced. The cross-platform `build` job in
+`.github/workflows/release.yml` was disabled to avoid unnecessary maintenance,
+since the project contains no C or Rust code.
 
 The process runs automatically when a git tag matching `v*.*.*` is pushed. For
 example:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -136,8 +136,9 @@ applications.
   - [ ] Add support for global hooks on `WebSocketRouter` and per-resource hooks
     on `WebSocketResource`.
 
-  - [ ] Implement the "onion-style" execution order and define the error
-    propagation behaviour for exceptions raised within the hook chain.
+  - [ ] Implement the "onion-style" execution order (outermost hooks run first)
+    and define the error propagation behaviour for exceptions raised within the
+    hook chain.
 
 - [ ] **Design and Implement Dependency Injection.**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,129 +1,178 @@
 # Falcon-Pachinko: Updated Development Roadmap
 
-This roadmap outlines the implementation tasks for the Falcon-Pachinko extension based on the revised, composable architecture detailed in the main design document. It supersedes the previous roadmap and reflects a pivot towards a more robust, scalable, and Falcon-idiomatic system.
+This roadmap outlines the implementation tasks for the Falcon-Pachinko extension
+based on the revised, composable architecture detailed in the main design
+document. It supersedes the previous roadmap and reflects a pivot towards a more
+robust, scalable, and Falcon-idiomatic system.
 
 ## Phase 1: Foundational Composable Router
 
-This phase replaces the initial `app.add_websocket_route` mechanism with the more powerful and modular `WebSocketRouter`. This is the most significant architectural change and underpins all subsequent features.
+This phase replaces the initial `app.add_websocket_route` mechanism with the
+more powerful and modular `WebSocketRouter`. This is the most significant
+architectural change and underpins all subsequent features.
 
 - [ ] **Deprecate the old routing API.**
 
-  - [ ] Mark `app.add_websocket_route` and `app.create_websocket_resource` for deprecation. The logic will be entirely superseded by the new router.
+  - [ ] Mark `app.add_websocket_route` and `app.create_websocket_resource` for
+    deprecation. The logic will be entirely superseded by the new router.
 
 - [ ] **Implement** `WebSocketRouter` **as a Falcon Resource.**
 
   - [ ] Create the new module `falcon_pachinko/router.py`.
 
-  - [ ] Define the `WebSocketRouter` class, ensuring it has an `on_websocket(req, ws)` responder method to make it a valid, mountable Falcon resource.
+  - [ ] Define the `WebSocketRouter` class, ensuring it has an
+    `on_websocket(req, ws)` responder method to make it a valid, mountable
+    Falcon resource.
 
-  - [ ] Implement the router's internal path-matching logic, leveraging `falcon.routing.compile_uri_template` to handle routes relative to its mount point.
+  - [ ] Implement the router's internal path-matching logic, leveraging
+    `falcon.routing.compile_uri_template` to handle routes relative to its mount
+    point.
 
 - [ ] **Implement the** `WebSocketRouter.add_route()` **API.**
 
-  - [ ] The method must accept a relative path, a name for URL reversal, and the target resource.
+  - [ ] The method must accept a relative path, a name for URL reversal, and the
+    target resource.
 
-  - [ ] Add support for both `WebSocketResource` classes and callable factories as route targets, mirroring Falcon's HTTP routing flexibility.
+  - [ ] Add support for both `WebSocketResource` classes and callable factories
+    as route targets, mirroring Falcon's HTTP routing flexibility.
 
-  - [ ] Add support for passing `*args` and `**kwargs` during route definition for resource initialization.
+  - [ ] Add support for passing `*args` and `**kwargs` during route definition
+    for resource initialization.
 
   - [ ] Implement `router.url_for(name, **params)` for reverse URL generation.
 
 - [ ] **Update Core Tests.**
 
-  - [ ] Write new integration tests to verify that a `WebSocketRouter` can be mounted on a Falcon `App`.
+  - [ ] Write new integration tests to verify that a `WebSocketRouter` can be
+    mounted on a Falcon `App`.
 
-  - [ ] Test that connections to routes defined on the router correctly instantiate the associated resource with the correct path parameters and initialization arguments.
+  - [ ] Test that connections to routes defined on the router correctly
+    instantiate the associated resource with the correct path parameters and
+    initialization arguments.
 
 ## Phase 2: Advanced Dispatch and Resource Model
 
-This phase refines the `WebSocketResource` to support the new schema-driven and composable patterns.
+This phase refines the `WebSocketResource` to support the new schema-driven and
+composable patterns.
 
 - [ ] **Integrate** `msgspec` **for Schema-Driven Dispatch.**
 
-  - [ ] Refactor the `WebSocketResource` dispatch loop to prioritize the `schema` attribute (a `msgspec` tagged union).
+  - [ ] Refactor the `WebSocketResource` dispatch loop to prioritize the
+    `schema` attribute (a `msgspec` tagged union).
 
-  - [ ] Implement the logic to decode messages against the schema and route to handlers based on the message tag.
+  - [ ] Implement the logic to decode messages against the schema and route to
+    handlers based on the message tag.
 
-  - [ ] Make the `@handles_message("type")` decorator the canonical, preferred way to register a handler.
+  - [ ] Make the `@handles_message("type")` decorator the canonical, preferred
+    way to register a handler.
 
-  - [ ] Implement the `on_{tag}` naming convention as a best-effort convenience, including the `CamelCase` to `snake_case` conversion.
+  - [ ] Implement the `on_{tag}` naming convention as a best-effort convenience,
+    including the `CamelCase` to `snake_case` conversion.
 
-  - [ ] Document `msgspec`'s default strictness (no extra fields) and expose a `strict=False` option on the decorator.
+  - [ ] Document `msgspec`'s default strictness (no extra fields) and expose a
+    `strict=False` option on the decorator.
 
 - [ ] **Refine Resource API and State Management.**
 
-  - [ ] Rename the fallback handler method from `on_message` to `on_unhandled` to avoid ambiguity.
+  - [ ] Rename the fallback handler method from `on_message` to `on_unhandled`
+    to avoid ambiguity.
 
-  - [ ] Implement the `self.state` attribute on `WebSocketResource` as a swappable, dict-like proxy to facilitate external session stores. Provide guidance on this pattern for high-concurrency scenarios.
+  - [ ] Implement the `self.state` attribute on `WebSocketResource` as a
+    swappable, dict-like proxy to facilitate external session stores. Provide
+    guidance on this pattern for high-concurrency scenarios.
 
 - [ ] **Implement Nested Resource Composition.**
 
-  - [ ] Add the `add_subroute(path, resource, ...)` method to `WebSocketResource`.
+  - [ ] Add the `add_subroute(path, resource, ...)` method to
+    `WebSocketResource`.
 
-  - [ ] Enhance the `WebSocketRouter`'s matching logic to handle multi-level nested paths.
+  - [ ] Enhance the `WebSocketRouter`'s matching logic to handle multi-level
+    nested paths.
 
-  - [ ] Design and implement a robust context-passing mechanism for parent resources to inject state into child resources.
+  - [ ] Design and implement a robust context-passing mechanism for parent
+    resources to inject state into child resources.
 
 ## Phase 3: Lifespan Workers and Connection Management
 
-This phase implements the redesigned, ASGI-native background worker system and finalizes the connection manager API.
+This phase implements the redesigned, ASGI-native background worker system and
+finalizes the connection manager API.
 
 - [ ] **Implement Lifespan-Based Worker Management.**
 
   - [ ] Create the new `falcon_pachinko/workers.py` module.
 
-  - [ ] Implement the `WorkerController` class with its `start()` and `stop()` methods.
+  - [ ] Implement the `WorkerController` class with its `start()` and `stop()`
+    methods.
 
   - [ ] Implement the optional `@worker` decorator for clarity.
 
-  - [ ] Update all examples and documentation to use the `@app.lifespan` pattern for managing workers, completely removing the old `add_websocket_worker` concept.
+  - [ ] Update all examples and documentation to use the `@app.lifespan` pattern
+    for managing workers, completely removing the old `add_websocket_worker`
+    concept.
 
 - [ ] **Finalize** `WebSocketConnectionManager` **API.**
 
-  - [ ] Refactor all I/O methods (e.g., `broadcast_to_room`) to be `async def` and ensure they propagate exceptions correctly.
+  - [ ] Refactor all I/O methods (e.g., `broadcast_to_room`) to be `async def`
+    and ensure they propagate exceptions correctly.
 
-  - [ ] Implement `async for` iterators (e.g., `conn_mgr.connections(room=...)`) for composable bulk operations.
+  - [ ] Implement `async for` iterators (e.g., `conn_mgr.connections(room=...)`)
+    for composable bulk operations.
 
-  - [ ] Define the abstract backend interface (ABC) for the connection manager to pave the way for future distributed backends.
+  - [ ] Define the abstract backend interface (ABC) for the connection manager
+    to pave the way for future distributed backends.
 
-  - [ ] Ensure the default `InProcessBackend` correctly implements this new, robust interface.
+  - [ ] Ensure the default `InProcessBackend` correctly implements this new,
+    robust interface.
 
 ## Phase 4: Cross-Cutting Concerns
 
-This phase adds the essential features for building production-grade applications.
+This phase adds the essential features for building production-grade
+applications.
 
 - [ ] **Implement the Multi-Tiered Hook System.**
 
   - [ ] Create a `HookManager` to orchestrate hook execution.
 
-  - [ ] Add support for global hooks on `WebSocketRouter` and per-resource hooks on `WebSocketResource`.
+  - [ ] Add support for global hooks on `WebSocketRouter` and per-resource hooks
+    on `WebSocketResource`.
 
-  - [ ] Implement the "onion-style" execution order and define the error propagation behaviour for exceptions raised within the hook chain.
+  - [ ] Implement the "onion-style" execution order and define the error
+    propagation behaviour for exceptions raised within the hook chain.
 
 - [ ] **Design and Implement Dependency Injection.**
 
-  - [ ] Formalize and implement a strategy for injecting shared services into ephemeral `WebSocketResource` instances. This will likely involve allowing a DI container or factory to be provided to the `WebSocketRouter`.
+  - [ ] Formalize and implement a strategy for injecting shared services into
+    ephemeral `WebSocketResource` instances. This will likely involve allowing a
+    DI container or factory to be provided to the `WebSocketRouter`.
 
 ## Phase 5: Testing, Documentation, and Examples
 
-This is an ongoing process, but it will be finalized in this phase to ensure the library is ready for use.
+This is an ongoing process, but it will be finalized in this phase to ensure the
+library is ready for use.
 
 - [ ] **Develop Comprehensive Testing Utilities.**
 
-  - [ ] Build a `WebSocketTestClient` or `WebSocketSimulator` for high-level integration testing.
+  - [ ] Build a `WebSocketTestClient` or `WebSocketSimulator` for high-level
+    integration testing.
 
-  - [ ] Ensure the test client API is intuitive and supports the full connection and message lifecycle.
+  - [ ] Ensure the test client API is intuitive and supports the full connection
+    and message lifecycle.
 
   - [ ] Provide pytest fixtures to simplify test setup.
 
 - [ ] **Build a Full Reference Example.**
 
-  - [ ] Create a new, comprehensive example application that demonstrates all the advanced features working in concert: a mountable router, schema-driven dispatch, nested resources, lifespan workers, hooks, and dependency injection.
+  - [ ] Create a new, comprehensive example application that demonstrates all
+    the advanced features working in concert: a mountable router, schema-driven
+    dispatch, nested resources, lifespan workers, hooks, and dependency
+    injection.
 
 - [ ] **Rewrite the Documentation.**
 
-  - [ ] Update the project's official documentation to reflect the new, composable architecture as the primary and recommended approach.
+  - [ ] Update the project's official documentation to reflect the new,
+    composable architecture as the primary and recommended approach.
 
   - [ ] Create a migration guide for users of the pre-release version.
 
-  - [ ] Add detailed "how-to" guides for advanced features like DI, state management, and custom connection manager backends.
+  - [ ] Add detailed "how-to" guides for advanced features like DI, state
+    management, and custom connection manager backends.

--- a/examples/random_status/server.py
+++ b/examples/random_status/server.py
@@ -96,9 +96,7 @@ class StatusResource(WebSocketResource):
             self._task.cancel()
 
     @handles_message("status")
-    async def update_status(
-        self, ws: WebSocketLike, payload: StatusPayload
-    ) -> None:
+    async def update_status(self, ws: WebSocketLike, payload: StatusPayload) -> None:
         """
         Handle incoming WebSocket "status" messages to update the stored status value.
 

--- a/falcon_pachinko/unittests/test_websocket_resource.py
+++ b/falcon_pachinko/unittests/test_websocket_resource.py
@@ -100,9 +100,7 @@ class RawResource(WebSocketResource):
         self.received.append(message)
 
 
-async def raw_handler(
-    self: RawResource, ws: WebSocketLike, payload: object
-) -> None:
+async def raw_handler(self: RawResource, ws: WebSocketLike, payload: object) -> None:
     """Handle incoming messages of type "raw".
 
     Handles incoming messages of type "raw" by appending the payload to the
@@ -169,9 +167,7 @@ async def test_handler_shared_across_instances() -> None:
         ("MISSING", None),
     ],
 )
-async def test_payload_type_none_passes_raw(
-    payload: object, expected: object
-) -> None:
+async def test_payload_type_none_passes_raw(payload: object, expected: object) -> None:
     """Tests that RawResource receives the raw payload as-is when no payload type is
     specified.
 


### PR DESCRIPTION
## Summary
- reformat markdown docs with `mdformat-all`

## Testing
- `markdownlint AGENTS.md README.md docs/release-workflow.md docs/roadmap.md`
- `nixie AGENTS.md README.md docs/release-workflow.md docs/roadmap.md`

------
https://chatgpt.com/codex/tasks/task_e_6861d7a86ea8832286ac8719ae0dff91

## Summary by Sourcery

Reformat Markdown documentation files for consistent wrapping, indentation, and style using mdformat-all

Enhancements:
- Standardize formatting across AGENTS.md, README.md, docs/roadmap.md, and docs/release-workflow.md

Tests:
- Ensure reformatted Markdown files pass markdownlint and nixie validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved readability and consistency in multiple documentation files by adjusting formatting, line breaks, and indentation.
  * No changes to content, instructions, or policies—only visual and structural enhancements for easier reading.
* **Style**
  * Simplified function signatures in example and test code by consolidating multi-line definitions into single lines without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->