### PR TITLE
Implement WebSocketRouter skeleton

### DIFF
--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -683,6 +683,39 @@ The `WebSocketRouter` must resolve these composite paths. A trie (prefix tree) i
 
 A critical aspect is **context passing**. The router must facilitate passing state from parent to child. A robust implementation would involve the router instantiating the entire resource chain, allowing parent resources to pass relevant state (or `self`) into the constructors of their children.
 
+```mermaid
+classDiagram
+    class WebSocketRouter {
+        - name: str | None
+        - _mount_path: str | None
+        - _router: CompiledRouter
+        - _routes: list[_Route]
+        - _name_map: dict[str, _Route]
+        + __init__(name: str | None)
+        + add_route(path, target, name, init_args, init_kwargs)
+        + url_for(name, **params)
+        + on_websocket(req, ws)
+    }
+    class _Route {
+        + path: str
+        + target: Callable[..., WebSocketResource] | type[WebSocketResource]
+        + args: tuple[Any, ...]
+        + kwargs: dict[str, Any]
+        + name: str | None
+    }
+    class WebSocketRouteNotFoundError
+    class DuplicateRouteNameError
+    WebSocketRouter --> _Route : uses
+    WebSocketRouter --> WebSocketRouteNotFoundError : raises
+    WebSocketRouter --> DuplicateRouteNameError : raises
+    _Route --> WebSocketResource : target
+    WebSocketRouter --> CompiledRouter : _router
+    note for WebSocketRouter "New class for composable WebSocket routing"
+    note for _Route "Internal dataclass for route info"
+    note for WebSocketRouteNotFoundError "Exception for missing route"
+    note for DuplicateRouteNameError "Exception for duplicate route name"
+```
+
 ### 5.3. High-Performance Schema-Driven Dispatch with `msgspec`
 
 This proposal elevates the dispatch mechanism using `msgspec` and its support for tagged unions. This moves from simple dispatch to a declarative, schema-driven approach.

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 MD040 MD033 -->
 # Falcon-Pachinko: A Design Proposal for Asynchronous WebSocket Routing and Handling in the Falcon Web Framework
 
 ## 1. Introduction

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,30 +13,30 @@ architectural change and underpins all subsequent features.
 
 - [ ] **Deprecate the old routing API.**
 
-  - [ ] Mark `app.add_websocket_route` and `app.create_websocket_resource` for
+  - [x] Mark `app.add_websocket_route` and `app.create_websocket_resource` for
     deprecation. The logic will be entirely superseded by the new router.
 
-- [ ] **Implement** `WebSocketRouter` **as a Falcon Resource.**
+- [x] **Implement** `WebSocketRouter` **as a Falcon Resource.**
 
-  - [ ] Create the new module `falcon_pachinko/router.py`.
+  - [x] Create the new module `falcon_pachinko/router.py`.
 
-  - [ ] Define the `WebSocketRouter` class, ensuring it has an
+  - [x] Define the `WebSocketRouter` class, ensuring it has an
     `on_websocket(req, ws)` responder method to make it a valid, mountable
     Falcon resource.
 
-  - [ ] Implement the router's internal path-matching logic, leveraging
+  - [x] Implement the router's internal path-matching logic, leveraging
     `falcon.routing.compile_uri_template` to handle routes relative to its mount
     point.
 
-- [ ] **Implement the** `WebSocketRouter.add_route()` **API.**
+- [x] **Implement the** `WebSocketRouter.add_route()` **API.**
 
-  - [ ] The method must accept a relative path, a name for URL reversal, and the
+  - [x] The method must accept a relative path, a name for URL reversal, and the
     target resource.
 
-  - [ ] Add support for both `WebSocketResource` classes and callable factories
+  - [x] Add support for both `WebSocketResource` classes and callable factories
     as route targets, mirroring Falcon's HTTP routing flexibility.
 
-  - [ ] Add support for passing `*args` and `**kwargs` during route definition
+  - [x] Add support for passing `*args` and `**kwargs` during route definition
     for resource initialization.
 
   - [ ] Implement `router.url_for(name, **params)` for reverse URL generation.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,7 @@ This phase replaces the initial `app.add_websocket_route` mechanism with the
 more powerful and modular `WebSocketRouter`. This is the most significant
 architectural change and underpins all subsequent features.
 
-- [ ] **Deprecate the old routing API.**
+- [x] **Deprecate the old routing API.**
 
   - [x] Mark `app.add_websocket_route` and `app.create_websocket_resource` for
     deprecation. The logic will be entirely superseded by the new router.
@@ -39,7 +39,7 @@ architectural change and underpins all subsequent features.
   - [x] Add support for passing `*args` and `**kwargs` during route definition
     for resource initialization.
 
-  - [ ] Implement `router.url_for(name, **params)` for reverse URL generation.
+  - [x] Implement `router.url_for(name, **params)` for reverse URL generation.
 
 - [ ] **Update Core Tests.**
 

--- a/falcon_pachinko/__init__.py
+++ b/falcon_pachinko/__init__.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from .resource import WebSocketLike, WebSocketResource, handles_message
+from .router import WebSocketRouter
 from .websocket import WebSocketConnectionManager, install
 
 __all__ = (
     "WebSocketConnectionManager",
     "WebSocketLike",
     "WebSocketResource",
+    "WebSocketRouter",
     "handles_message",
     "install",
 )

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -33,9 +33,11 @@ class DuplicateRouteNameError(ValueError):
 class WebSocketRouter:
     """Route WebSocket connections relative to its mount point."""
 
-    def __init__(self, *, name: str | None = None) -> None:
+    def __init__(
+        self, *, name: str | None = None, mount_path: str | None = None
+    ) -> None:
         self.name = name
-        self._mount_path: str | None = None
+        self._mount_path: str | None = mount_path
         self._router = compiled.CompiledRouter()
         self._routes: list[_Route] = []
         self._name_map: dict[str, _Route] = {}
@@ -78,9 +80,11 @@ class WebSocketRouter:
         self, req: falcon.Request, ws: WebSocketLike
     ) -> WebSocketResource:
         """Handle a WebSocket connection dispatched to this router."""
-        if self._mount_path is None:
-            self._mount_path = req.uri_template
-        path = req.path[len(self._mount_path) :] or "/"
+        mount_path = self._mount_path
+        if mount_path is None:
+            mount_path = req.uri_template
+            self._mount_path = mount_path
+        path = req.path[len(mount_path) :] or "/"
         match = self._router.find(path)
         if not match:
             raise WebSocketRouteNotFoundError(path)

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -1,0 +1,94 @@
+"""Composable WebSocket routing utilities."""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import typing
+
+import falcon.routing.compiled as compiled
+
+if typing.TYPE_CHECKING:
+    import falcon
+
+    from .resource import WebSocketLike, WebSocketResource
+
+
+@dc.dataclass(slots=True)
+class _Route:
+    path: str
+    target: typing.Callable[..., WebSocketResource] | type[WebSocketResource]
+    args: tuple[typing.Any, ...]
+    kwargs: dict[str, typing.Any]
+    name: str | None
+
+
+class WebSocketRouteNotFoundError(LookupError):
+    """Raised when no matching WebSocket route exists."""
+
+
+class DuplicateRouteNameError(ValueError):
+    """Raised when attempting to reuse a route name."""
+
+
+class WebSocketRouter:
+    """Route WebSocket connections relative to its mount point."""
+
+    def __init__(self, *, name: str | None = None) -> None:
+        self.name = name
+        self._mount_path: str | None = None
+        self._router = compiled.CompiledRouter()
+        self._routes: list[_Route] = []
+        self._name_map: dict[str, _Route] = {}
+
+    def add_route(
+        self,
+        path: str,
+        target: typing.Callable[..., WebSocketResource] | type[WebSocketResource],
+        *,
+        name: str | None = None,
+        init_args: tuple[typing.Any, ...] | None = None,
+        init_kwargs: dict[str, typing.Any] | None = None,
+    ) -> None:
+        """Register ``target`` to handle connections for ``path``."""
+        if name and name in self._name_map:
+            raise DuplicateRouteNameError(name)
+
+        route = _Route(
+            path,
+            target,
+            init_args or (),
+            init_kwargs or {},
+            name,
+        )
+        self._router.add_route(path, route)
+        self._routes.append(route)
+        if name:
+            self._name_map[name] = route
+
+    def url_for(self, name: str, **params: str) -> str:
+        """Return the relative URI for the named route."""
+        route = self._name_map[name]
+        return route.path.format(**params)
+
+    async def on_websocket(
+        self, req: falcon.Request, ws: WebSocketLike
+    ) -> WebSocketResource:
+        """Handle a WebSocket connection dispatched to this router."""
+        if self._mount_path is None:
+            self._mount_path = req.uri_template
+        path = req.path[len(self._mount_path) :]
+        if not path:
+            path = "/"
+        match = self._router.find(path)
+        if not match:
+            raise WebSocketRouteNotFoundError(path)
+        route = typing.cast("_Route", match[0])
+        params = match[2]
+        target = route.target
+        resource: WebSocketResource
+        if isinstance(target, type):
+            resource = target(*route.args, **route.kwargs)
+        else:
+            resource = target(*route.args, **route.kwargs)
+        await resource.on_connect(req, ws, **params)
+        return resource

--- a/falcon_pachinko/unittests/test_router.py
+++ b/falcon_pachinko/unittests/test_router.py
@@ -3,10 +3,19 @@
 from __future__ import annotations
 
 import types
+import typing
 
 import pytest
 
-from falcon_pachinko import WebSocketLike, WebSocketResource, WebSocketRouter
+from falcon_pachinko import (
+    WebSocketLike,
+    WebSocketResource,
+    WebSocketRouter,
+)
+from falcon_pachinko.router import DuplicateRouteNameError, WebSocketRouteNotFoundError
+
+if typing.TYPE_CHECKING:  # pragma: no cover - imports for type hints only
+    import falcon
 from falcon_pachinko.unittests.helpers import DummyWS
 
 
@@ -18,7 +27,7 @@ class DummyResource(WebSocketResource):
         self.params: dict[str, str] | None = None
 
     async def on_connect(
-        self, req: types.SimpleNamespace, ws: WebSocketLike, **params: str
+        self, req: falcon.Request, ws: WebSocketLike, **params: str
     ) -> bool:
         """Record connection parameters for assertions."""
         self.params = params
@@ -47,3 +56,38 @@ def test_url_for_generates_path() -> None:
 
     path = router.url_for("thing", tid="99")
     assert path == "/things/99"
+
+
+def test_duplicate_route_name_raises() -> None:
+    """``add_route`` should reject duplicate names."""
+    router = WebSocketRouter()
+    router.add_route("/a", DummyResource, name="dup")
+
+    with pytest.raises(DuplicateRouteNameError):
+        router.add_route("/b", DummyResource, name="dup")
+
+
+@pytest.mark.asyncio
+async def test_route_not_found() -> None:
+    """``on_websocket`` should raise for unknown paths."""
+    router = WebSocketRouter()
+    req = types.SimpleNamespace(path="/missing", uri_template="/ws")
+
+    with pytest.raises(WebSocketRouteNotFoundError):
+        await router.on_websocket(req, DummyWS())
+
+
+@pytest.mark.asyncio
+async def test_callable_target_supported() -> None:
+    """The router should handle callables as targets."""
+
+    def factory() -> WebSocketResource:
+        return DummyResource(2)
+
+    router = WebSocketRouter()
+    router.add_route("/", factory, name="home")
+
+    req = types.SimpleNamespace(path="/ws/", uri_template="/ws")
+    res = await router.on_websocket(req, DummyWS())
+    assert isinstance(res, DummyResource)
+    assert res.value == 2

--- a/falcon_pachinko/unittests/test_router.py
+++ b/falcon_pachinko/unittests/test_router.py
@@ -1,0 +1,49 @@
+"""Tests for the :mod:`falcon_pachinko.router` module."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from falcon_pachinko import WebSocketLike, WebSocketResource, WebSocketRouter
+from falcon_pachinko.unittests.helpers import DummyWS
+
+
+class DummyResource(WebSocketResource):
+    """A simple resource used in router tests."""
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+        self.params: dict[str, str] | None = None
+
+    async def on_connect(
+        self, req: types.SimpleNamespace, ws: WebSocketLike, **params: str
+    ) -> bool:
+        """Record connection parameters for assertions."""
+        self.params = params
+        return True
+
+
+@pytest.mark.asyncio
+async def test_router_dispatches_to_route() -> None:
+    """Verify that ``on_websocket`` instantiates the correct resource."""
+    router = WebSocketRouter()
+    router.add_route("/{id}", DummyResource, init_args=(1,), name="item")
+
+    req = types.SimpleNamespace(path="/ws/42", uri_template="/ws")
+    ws = DummyWS()
+    resource = await router.on_websocket(req, ws)
+
+    assert isinstance(resource, DummyResource)
+    assert resource.value == 1
+    assert resource.params == {"id": "42"}
+
+
+def test_url_for_generates_path() -> None:
+    """Ensure ``url_for`` fills in path parameters."""
+    router = WebSocketRouter(name="r")
+    router.add_route("/things/{tid}", DummyResource, name="thing")
+
+    path = router.url_for("thing", tid="99")
+    assert path == "/things/99"

--- a/falcon_pachinko/unittests/test_router.py
+++ b/falcon_pachinko/unittests/test_router.py
@@ -40,7 +40,9 @@ async def test_router_dispatches_to_route() -> None:
     router = WebSocketRouter()
     router.add_route("/{id}", DummyResource, init_args=(1,), name="item")
 
-    req = types.SimpleNamespace(path="/ws/42", uri_template="/ws")
+    req = typing.cast(
+        "falcon.Request", types.SimpleNamespace(path="/ws/42", uri_template="/ws")
+    )
     ws = DummyWS()
     resource = await router.on_websocket(req, ws)
 
@@ -71,7 +73,9 @@ def test_duplicate_route_name_raises() -> None:
 async def test_route_not_found() -> None:
     """``on_websocket`` should raise for unknown paths."""
     router = WebSocketRouter()
-    req = types.SimpleNamespace(path="/missing", uri_template="/ws")
+    req = typing.cast(
+        "falcon.Request", types.SimpleNamespace(path="/missing", uri_template="/ws")
+    )
 
     with pytest.raises(WebSocketRouteNotFoundError):
         await router.on_websocket(req, DummyWS())
@@ -87,7 +91,9 @@ async def test_callable_target_supported() -> None:
     router = WebSocketRouter()
     router.add_route("/", factory, name="home")
 
-    req = types.SimpleNamespace(path="/ws/", uri_template="/ws")
+    req = typing.cast(
+        "falcon.Request", types.SimpleNamespace(path="/ws/", uri_template="/ws")
+    )
     res = await router.on_websocket(req, DummyWS())
     assert isinstance(res, DummyResource)
     assert res.value == 2

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -235,9 +235,6 @@ def _add_websocket_route(
     .. deprecated:: 0.1.0
        Use :class:`falcon_pachinko.router.WebSocketRouter` instead.
 
-    .. deprecated:: 0.1.0
-       Use :class:`falcon_pachinko.router.WebSocketRouter` instead.
-
     Any ``init_args`` or ``init_kwargs`` supplied are stored and applied when
     ``create_websocket_resource`` is called. This allows a single resource class
     to be configured differently across multiple routes.

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import dataclasses as dc
 import typing
+import warnings
 from threading import Lock
 from types import MethodType
 
@@ -231,6 +232,12 @@ def _add_websocket_route(
 ) -> None:
     """Register ``resource_cls`` to handle connections for ``path``.
 
+    .. deprecated:: 0.1.0
+       Use :class:`falcon_pachinko.router.WebSocketRouter` instead.
+
+    .. deprecated:: 0.1.0
+       Use :class:`falcon_pachinko.router.WebSocketRouter` instead.
+
     Any ``init_args`` or ``init_kwargs`` supplied are stored and applied when
     ``create_websocket_resource`` is called. This allows a single resource class
     to be configured differently across multiple routes.
@@ -248,6 +255,11 @@ def _add_websocket_route(
     **init_kwargs : object
         Keyword arguments for resource initialization
     """
+    warnings.warn(
+        "app.add_websocket_route is deprecated; use WebSocketRouter",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     _validate_route_path(path)
     _validate_resource_cls(resource_cls)
     with self._websocket_route_lock:
@@ -264,6 +276,9 @@ def _add_websocket_route(
 
 def _create_websocket_resource(self: typing.Any, path: str) -> WebSocketResource:  # noqa: ANN401
     """Instantiate and return the WebSocket resource registered for ``path``.
+
+    .. deprecated:: 0.1.0
+       Use :class:`falcon_pachinko.router.WebSocketRouter` instead.
 
     Initialization parameters provided to :func:`add_websocket_route` are
     forwarded to the resource constructor.
@@ -285,6 +300,11 @@ def _create_websocket_resource(self: typing.Any, path: str) -> WebSocketResource
     ValueError
         If no resource class is registered for ``path``
     """
+    warnings.warn(
+        "app.create_websocket_resource is deprecated; use WebSocketRouter",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     with self._websocket_route_lock:
         routes = self._websocket_routes
         try:


### PR DESCRIPTION
## Summary
- mark the old WebSocket APIs as deprecated
- introduce `WebSocketRouter` and supporting exceptions
- expose the router in the package API
- add basic router unit tests
- update the roadmap for completed router tasks

## Testing
- `ruff format falcon_pachinko/router.py falcon_pachinko/__init__.py falcon_pachinko/websocket.py > /tmp/ruff_format.log && tail -n 20 /tmp/ruff_format.log`
- `ruff check falcon_pachinko/router.py falcon_pachinko/__init__.py falcon_pachinko/websocket.py > /tmp/ruff_check.log && tail -n 20 /tmp/ruff_check.log`
- `ruff check falcon_pachinko/unittests/test_router.py > /tmp/ruff_check.log && cat /tmp/ruff_check.log`
- `markdownlint docs/roadmap.md > /tmp/mdlint.log && cat /tmp/mdlint.log`
- `pyright > /tmp/pyright.log && tail -n 20 /tmp/pyright.log` *(fails: Import errors)*
- `ty check > /tmp/ty.log && tail -n 20 /tmp/ty.log` *(fails: unresolved imports)*
- `pytest -q > /tmp/pytest.log && tail -n 20 /tmp/pytest.log` *(fails: ModuleNotFoundError: falcon_pachinko)*

------
https://chatgpt.com/codex/tasks/task_e_68666c4b4c14832287413d4b57de7508

## Summary by Sourcery

Add a new WebSocketRouter module to handle routing of WebSocket connections, deprecate the legacy routing methods, update the package export and documentation, and include basic router tests.

New Features:
- Introduce WebSocketRouter with add_route, url_for, and on_websocket methods for composable WebSocket routing
- Expose WebSocketRouter in the package API

Enhancements:
- Deprecate the old add_websocket_route and create_websocket_resource APIs with warnings and deprecation notices

Documentation:
- Update roadmap.md to mark the new router implementation and old API deprecation as completed

Tests:
- Add unit tests to verify router dispatch behavior and URL generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a composable WebSocket router for structured and parameterized WebSocket routing.
  * Added support for named WebSocket routes and URL generation.

* **Documentation**
  * Updated roadmap to reflect completed foundational routing tasks.
  * Added deprecation notes in documentation for legacy WebSocket routing methods.
  * Added a detailed class diagram illustrating the WebSocketRouter design.

* **Tests**
  * Added tests to verify WebSocket router dispatch, URL generation, and error handling.

* **Chores**
  * Deprecated legacy WebSocket routing methods with runtime warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->