### PR TITLE
Add Makefile tooling and update workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,16 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Install dependencies
-        run: |
-          uv pip install --system --group dev --group examples .
-
       - name: Install CLI tools
         run: |
-          uv pip install --system slipcover pytest-forked mbake ty
-          uv tool install mdformat nixie
+          uv tool install mbake ty ruff
           npm install -g markdownlint-cli2
 
       - name: Validate Makefile
         run: mbake validate Makefile
+
+      - name: Install code
+        run: make build
 
       - name: Check formatting
         run: make check-fmt
@@ -42,12 +40,13 @@ jobs:
       - name: Run ruff
         run: make lint
 
-      - name: Run pyright
+      - name: Run typechecker
         run: make typecheck
 
       - name: Run tests with coverage
         run: |
-          python -m slipcover \
+          uv pip install slipcover pytest-forked
+          uv run python -m slipcover \
             --source=./falcon_pachinko \
             --omit="*/unittests/*,*/.venv/*" \
             --branch \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install CLI tools
         run: |
-          uv tool install mbake ty ruff
+          for tool in mbake ty ruff; do uv tool install ${tool}; done
           npm install -g markdownlint-cli2
 
       - name: Validate Makefile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,12 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install --system --group dev --group examples .
-          uv pip install --system slipcover pytest-forked mbake
+
+      - name: Install CLI tools
+        run: |
+          uv pip install --system slipcover pytest-forked mbake ty
+          uv tool install mdformat nixie
+          npm install -g markdownlint-cli2
 
       - name: Validate Makefile
         run: mbake validate Makefile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,17 +25,20 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --system --group dev .
-          uv pip install --system slipcover pytest-forked
+          uv pip install --system --group dev --group examples .
+          uv pip install --system slipcover pytest-forked mbake
+
+      - name: Validate Makefile
+        run: mbake validate Makefile
 
       - name: Check formatting
-        run: ruff format --check .
+        run: make check-fmt
 
       - name: Run ruff
-        run: ruff check .
+        run: make lint
 
       - name: Run pyright
-        run: pyright
+        run: make typecheck
 
       - name: Run tests with coverage
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,10 @@ When implementing changes, adhere to the following testing procedures:
   development environment, running linters, formatting, type checking, and
   tests. Use `make build` to create the local virtual environment with both the
   `dev` and `examples` dependency groups. Prefer these targets over invoking
-  tools directly.
+  tools directly. When editing `Makefile`, run `mbake validate Makefile` to
+  confirm the syntax is correct. The `dev` dependency group includes all CLI
+  tooling such as linters and markdown checks, so `make build` installs
+  everything required for development and CI.
 
 - **Atomicity:** Aim for small, focused, atomic changes. Each change (and
   subsequent commit) should represent a single logical unit of work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,10 +63,18 @@ When implementing changes, adhere to the following testing procedures:
 
 ## Change Quality & Committing
 
+- **Use the Makefile.** The root `Makefile` defines targets for setting up the
+  development environment, running linters, formatting, type checking, and
+  tests. Use `make build` to create the local virtual environment with both the
+  `dev` and `examples` dependency groups. Prefer these targets over invoking
+  tools directly.
+
 - **Atomicity:** Aim for small, focused, atomic changes. Each change (and
   subsequent commit) should represent a single logical unit of work.
+
 - **Quality Gates:** Before considering a change complete or proposing a commit,
   ensure it meets the following criteria:
+
   - For Python files:
 
     - **Testing:** Passes all relevant unit and behavioral tests according to
@@ -89,7 +97,9 @@ When implementing changes, adhere to the following testing procedures:
 
     - **Linting:** Passes lint checks (`markdownlint filename.md`).
     - **Mermaid diagrams:** Passes validation using nixie (`nixie filename.md`)
+
 - **Committing:**
+
   - Only changes that meet all the quality gates above should be committed.
   - Write clear, descriptive commit messages summarizing the change, following
     these formatting guidelines:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TOOLS = $(MDFORMAT_ALL) ruff ty $(MDLINT) $(NIXIE) uv
 VENV_TOOLS = pytest
 
 .PHONY: help all clean build build-release lint fmt check-fmt \
-	markdownlint tools nixie test typecheck $(TOOLS) $(VENV_TOOLS)
+	markdownlint nixie test typecheck $(TOOLS) $(VENV_TOOLS)
 
 .DEFAULT_GOAL := build
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VENV_TOOLS = pytest
 .PHONY: help all clean build build-release lint fmt check-fmt \
 	markdownlint nixie test typecheck $(TOOLS) $(VENV_TOOLS)
 
-.DEFAULT_GOAL := build
+.DEFAULT_GOAL := all
 
 all: build check-fmt test typecheck
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MDFORMAT_ALL ?= $(shell which mdformat-all)
 TOOLS = $(MDFORMAT_ALL) ruff ty $(MDLINT) $(NIXIE) uv
 VENV_TOOLS = pytest
 
-.PHONY: help default all clean build build-release lint fmt check-fmt \
+.PHONY: help all clean build build-release lint fmt check-fmt \
 	markdownlint tools nixie test typecheck $(TOOLS) $(VENV_TOOLS)
 
 .DEFAULT_GOAL := build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+.PHONY: help default all clean build build-release lint fmt check-fmt \
+	markdownlint tools nixie test typecheck
+
+MDLINT ?= markdownlint
+NIXIE ?= nixie
+
+all: build check-fmt test typecheck
+
+default: build
+
+build: tools ## Build for test/typecheck
+	uv venv
+	uv sync --group dev --group examples
+
+build-release: ## Build artefacts (sdist & wheel)
+	python -m build --sdist --wheel
+
+clean: ## Remove build artifacts
+	rm -rf build dist *.egg-info \
+	  .mypy_cache .pytest_cache .coverage coverage.* lcov.info htmlcov \
+	  .venv
+	find . -type d -name '__pycache__' -exec rm -rf '{}' +
+
+define ensure_tool
+$(if $(shell command -v $(1) >/dev/null 2>&1 && echo y),,\
+$(error $(1) is required but not installed))
+endef
+
+
+TOOLS = mdformat-all ruff ty $(MDLINT) $(NIXIE) pytest uv
+
+tools: ## Verify required CLI tools
+	$(foreach t,$(TOOLS),$(call ensure_tool,$t))
+	@:
+
+fmt: tools ## Format sources
+	ruff format
+	mdformat-all
+
+check-fmt: ## Verify formatting
+	ruff format --check
+	mdformat-all --check
+
+lint: tools ## Run linters
+	ruff check
+
+typecheck: build ## Run typechecking
+	uv run pyright
+	uv run ty check
+
+markdownlint: tools ## Lint Markdown files
+	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(MDLINT)
+
+nixie: tools ## Validate Mermaid diagrams
+	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(NIXIE)
+
+test: build ## Run tests
+	uv run pytest -v
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \
+	awk 'BEGIN {FS=":"; printf "Available targets:\n"} {printf "  %-20s %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help default all clean build build-release lint fmt check-fmt \
-	markdownlint tools nixie test typecheck
+       markdownlint tools nixie test typecheck
 
 MDLINT ?= markdownlint
 NIXIE ?= nixie
@@ -8,7 +8,7 @@ all: build check-fmt test typecheck
 
 default: build
 
-build: tools ## Build for test/typecheck
+build: ## Build virtual-env and install deps
 	uv venv
 	uv sync --group dev --group examples
 
@@ -22,8 +22,8 @@ clean: ## Remove build artifacts
 	find . -type d -name '__pycache__' -exec rm -rf '{}' +
 
 define ensure_tool
-$(if $(shell command -v $(1) >/dev/null 2>&1 && echo y),,\
-$(error $(1) is required but not installed))
+$(if $(shell uv run --which $(1) >/dev/null 2>&1 && echo y),,\
+$(error $(1) is required but not installed in the uv environment))
 endef
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ examples = ["aiosqlite", "uvicorn", "websocket-client"]
 [tool.pyright]
 pythonVersion = "3.13"
 typeCheckingMode = "strict"
-include = ["falcon_pachinko", "examples"]
+include = ["falcon_pachinko"]
 
 [tool.uv]
 package = true


### PR DESCRIPTION
## Summary
- update Makefile to install example deps and run typecheck in virtualenv
- document usage of `make build` in AGENTS guide
- run Makefile targets in CI with example dependency group
- restrict pyright to package code only

## Testing
- `ruff check .`
- `ruff format --check .`
- `make typecheck`
- `make test`
- `markdownlint AGENTS.md`


------
https://chatgpt.com/codex/tasks/task_e_6866b0246ec88322ae8a9aefa31c8d24

## Summary by Sourcery

Introduce a Makefile to unify development commands, update CI workflows to invoke Makefile targets and install example dependencies, tighten type checking configuration, and document the new tooling in the project guide.

New Features:
- Add root Makefile with targets for building environments, formatting, linting, type checking, testing, and documentation checks

Enhancements:
- Restrict Pyright analysis to the main package code only

CI:
- Include example dependencies in CI installation
- Validate Makefile in CI and replace direct lint/format/typecheck commands with Makefile targets

Documentation:
- Document Makefile usage and the `make build` command in the AGENTS guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Makefile with convenient commands for building, testing, linting, formatting, type checking, and cleaning the project.

* **Documentation**
  * Updated guidelines to recommend using the Makefile for common development tasks and validating its syntax.

* **Chores**
  * Improved the continuous integration workflow to use Makefile targets for formatting, linting, and type checking.
  * Added installation of additional CLI tools and validation steps in CI.
  * Adjusted type checking configuration to focus on the main package and exclude examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->