### PR TITLE
Add WebSocketRouter and deprecate helpers

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,8 +1,0 @@
-{
-  "ignores": [
-    "docs/falcon-websocket-extension-design.md",
-    "docs/guide-to-modern-python-code-coverage.md",
-    "AGENTS.md",
-    "**/.venv/**"
-  ]
-}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,6 +1,8 @@
 {
   "ignores": [
     "docs/falcon-websocket-extension-design.md",
-    "docs/guide-to-modern-python-code-coverage.md"
+    "docs/guide-to-modern-python-code-coverage.md",
+    "AGENTS.md",
+    "**/.venv/**"
   ]
 }

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,6 @@
+{
+  "ignores": [
+    "docs/falcon-websocket-extension-design.md",
+    "docs/guide-to-modern-python-code-coverage.md"
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ $(VENV_TOOLS): ## Verify required CLI tools in venv
 
 fmt: ruff $(MDFORMAT_ALL) ## Format sources
 	ruff format
+	ruff check --select I --fix
 	$(MDFORMAT_ALL)
 
 check-fmt: ruff ## Verify formatting

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,15 @@ $(TOOLS): ## Verify required CLI tools
 $(VENV_TOOLS): ## Verify required CLI tools in venv
 	$(call ensure_tool_venv,$@)
 
-fmt: ruff $(MDFORMAT_ALL) ## Format sources
+fmt: ruff ## Format sources
 	ruff format
 	ruff check --select I --fix
-	$(MDFORMAT_ALL)
+	mdformat --number --wrap 80 AGENTS.md README.md \
+	docs/release-workflow.md docs/roadmap-v1-legacy.md docs/roadmap.md
+	mdtablefix --in-place AGENTS.md README.md \
+	docs/release-workflow.md docs/roadmap-v1-legacy.md docs/roadmap.md
+	markdownlint --fix AGENTS.md README.md \
+	docs/release-workflow.md docs/roadmap-v1-legacy.md docs/roadmap.md
 
 check-fmt: ruff ## Verify formatting
 	ruff format --check
@@ -60,7 +65,10 @@ typecheck: build ty ## Run typechecking
 	ty check
 
 markdownlint: $(MDLINT) ## Lint Markdown files
-	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(MDLINT)
+	find . -type f -name '*.md' -not -path './target/*' \
+	! -path './docs/falcon-websocket-extension-design.md' \
+	! -path './docs/guide-to-modern-python-code-coverage.md' \
+	! -path './AGENTS.md' -print0 | xargs -0 $(MDLINT)
 
 nixie: $(NIXIE) ## Validate Mermaid diagrams
 	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(NIXIE)

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -93,7 +93,9 @@ This `install` function would instantiate the `WebSocketConnectionManager` and m
 
 ### 3.4. Routing WebSocket Connections
 
-Analogous to Falcon's HTTP routing (`app.add_route()`), the extension will provide a method to associate a URL path with a `WebSocketResource`:
+Analogous to Falcon's HTTP routing (`app.add_route()`), the extension originally provided `app.add_websocket_route()` to associate a URL path with a `WebSocketResource`.
+
+> **Deprecated**: Use :meth:`falcon_pachinko.router.WebSocketRouter.add_route` instead.
 
 ```
 app.add_websocket_route(
@@ -123,6 +125,8 @@ sequenceDiagram
 #### 3.4.1. Programmatic Resource Instantiation
 
 Application code can also create a resource instance directly using `app.create_websocket_resource(path)`. This helper returns a new object of the class registered for `path` or raises `ValueError` if no such route exists.
+
+> **Deprecated**: Use a :class:`WebSocketRouter` and instantiate resources via its `add_route` API.
 
 ```python
 chat_resource = app.create_websocket_resource('/ws/chat/{room_name}')
@@ -648,6 +652,71 @@ app.add_route('/ws/chat', chat_router)
 ```
 
 The router is responsible for matching the incoming connection URI against its registered routes, parsing any path parameters (like `{room_id}`), instantiating the correct `WebSocketResource` with its specific initialization arguments, and handing off control of the connection.
+
+#### 5.1.3. Router Flow and Structure
+
+The diagrams below illustrate the flow of a WebSocket connection through the router and the relationships between the main classes.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant FalconApp
+    participant WebSocketRouter
+    participant WebSocketResource
+
+    Client->>FalconApp: Initiate WebSocket connection (URL)
+    FalconApp->>WebSocketRouter: on_websocket(req, ws)
+    WebSocketRouter->>WebSocketRouter: Match URL to route
+    WebSocketRouter->>WebSocketResource: Instantiate resource
+    WebSocketRouter->>WebSocketResource: on_connect(req, ws, **params)
+    alt on_connect returns False
+        WebSocketRouter->>Client: Close WebSocket
+    else on_connect returns True
+        WebSocketRouter->>Client: Accept WebSocket
+    end
+```
+
+```mermaid
+erDiagram
+    WEBSOCKETROUTER ||--o{ ROUTE : registers
+    ROUTE {
+        string path
+        regex pattern
+        callable factory
+    }
+    WEBSOCKETROUTER {
+        string name
+        dict names
+    }
+    ROUTE }o--|| WEBSOCKETRESOURCE : instantiates
+    WEBSOCKETRESOURCE {
+        method on_connect
+    }
+```
+
+```mermaid
+classDiagram
+    class WebSocketRouter {
+        - _routes: list[tuple[str, re.Pattern[str], Callable[..., WebSocketResource]]]
+        - _names: dict[str, str]
+        - name: str | None
+        + __init__(name: str | None = None)
+        + add_route(path: str, resource: type[WebSocketResource] | Callable[..., WebSocketResource], name: str | None = None, args: tuple = (), kwargs: dict | None = None)
+        + url_for(name: str, **params: object) str
+        + on_websocket(req: falcon.Request, ws: WebSocketLike)
+    }
+    class WebSocketResource {
+        + on_connect(req: falcon.Request, ws: WebSocketLike, **params)
+    }
+    class WebSocketLike
+    class falcon.Request
+
+    WebSocketRouter --> WebSocketResource : creates
+    WebSocketRouter ..> WebSocketLike : uses
+    WebSocketRouter ..> falcon.Request : uses
+    WebSocketResource ..> WebSocketLike : uses
+    WebSocketResource ..> falcon.Request : uses
+```
 
 ### 5.2. Composable Architecture: Nested Resources
 

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -126,7 +126,7 @@ sequenceDiagram
 
 Application code can also create a resource instance directly using `app.create_websocket_resource(path)`. This helper returns a new object of the class registered for `path` or raises `ValueError` if no such route exists.
 
-> **Deprecated**: Use a :class:`WebSocketRouter` and instantiate resources via its `add_route` API.
+> **Deprecated**: A :class:`WebSocketRouter` and its `add_route` API should be used to instantiate resources.
 
 ```python
 chat_resource = app.create_websocket_resource('/ws/chat/{room_name}')

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,16 +11,16 @@ This phase replaces the initial `app.add_websocket_route` mechanism with the
 more powerful and modular `WebSocketRouter`. This is the most significant
 architectural change and underpins all subsequent features.
 
-- [ ] **Deprecate the old routing API.**
+- [x] **Deprecate the old routing API.**
 
-  - [ ] Mark `app.add_websocket_route` and `app.create_websocket_resource` for
+  - [x] Mark `app.add_websocket_route` and `app.create_websocket_resource` for
     deprecation. The logic will be entirely superseded by the new router.
 
-- [ ] **Implement** `WebSocketRouter` **as a Falcon Resource.**
+- [x] **Implement** `WebSocketRouter` **as a Falcon Resource.**
 
-  - [ ] Create the new module `falcon_pachinko/router.py`.
+  - [x] Create the new module `falcon_pachinko/router.py`.
 
-  - [ ] Define the `WebSocketRouter` class, ensuring it has an
+  - [x] Define the `WebSocketRouter` class, ensuring it has an
     `on_websocket(req, ws)` responder method to make it a valid, mountable
     Falcon resource.
 

--- a/falcon_pachinko/__init__.py
+++ b/falcon_pachinko/__init__.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from .resource import WebSocketLike, WebSocketResource, handles_message
+from .router import WebSocketRouter
 from .websocket import WebSocketConnectionManager, install
 
 __all__ = (
     "WebSocketConnectionManager",
     "WebSocketLike",
     "WebSocketResource",
+    "WebSocketRouter",
     "handles_message",
     "install",
 )

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -123,7 +123,7 @@ class WebSocketRouter:
                 f"path_template '{prefix}' is not a prefix of request path '{req.path}'"
             )
             raise falcon.HTTPNotFound(description=msg)
-        subpath = req.path[len(prefix) :] if prefix else req.path
+        subpath = req.path[len(prefix):] if prefix else req.path
         subpath = subpath or "/"
 
         # Routes are tested in the order they were added. Register more

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -42,6 +42,10 @@ class WebSocketRouter:
         if kwargs is None:
             kwargs = {}
 
+        if not callable(resource):
+            msg = "resource must be callable"
+            raise TypeError(msg)
+
         factory = functools.partial(resource, *args, **kwargs)
 
         self._routes.append((path, _compile_template(path), factory))
@@ -50,7 +54,12 @@ class WebSocketRouter:
 
     def url_for(self, name: str, **params: object) -> str:
         """Return the URL path associated with ``name`` formatted with ``params``."""
-        template = self._names[name]
+        try:
+            template = self._names[name]
+        except KeyError as exc:
+            msg = f"no route registered with name {name!r}"
+            raise KeyError(msg) from exc
+
         return template.format(**params)
 
     async def on_websocket(

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -123,7 +123,7 @@ class WebSocketRouter:
                 f"path_template '{prefix}' is not a prefix of request path '{req.path}'"
             )
             raise falcon.HTTPNotFound(description=msg)
-        subpath = req.path[len(prefix):] if prefix else req.path
+        subpath = req.path[len(prefix) :] if prefix else req.path
         subpath = subpath or "/"
 
         # Routes are tested in the order they were added. Register more

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -37,7 +37,7 @@ def _compile_template(template: str) -> re.Pattern[str]:
 def _normalize_path(path: str) -> str:
     """Ensure the path has a leading slash."""
     if not path.startswith("/"):
-        path = "/" + path
+        path = f"/{path}"
     return path
 
 
@@ -129,8 +129,7 @@ class WebSocketRouter:
         # Routes are tested in the order they were added. Register more
         # specific paths before general ones to control precedence.
         for _template, pattern, factory in self._routes:
-            match = pattern.fullmatch(subpath)
-            if match:
+            if match := pattern.fullmatch(subpath):
                 try:
                     resource = factory()
                     should_accept = await resource.on_connect(

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -1,0 +1,75 @@
+"""WebSocket routing utilities."""
+
+from __future__ import annotations
+
+import re
+import typing
+
+import falcon
+
+if typing.TYPE_CHECKING:
+    from .resource import WebSocketLike, WebSocketResource
+
+
+def _compile_template(template: str) -> re.Pattern[str]:
+    pattern = re.sub(r"{([^}]+)}", r"(?P<\1>[^/]+)", template.rstrip("/"))
+    pattern = f"^{pattern}$"
+    return re.compile(pattern)
+
+
+class WebSocketRouter:
+    """Minimal Falcon resource for routing WebSocket connections."""
+
+    def __init__(self, *, name: str | None = None) -> None:
+        self._routes: list[
+            tuple[str, re.Pattern[str], typing.Callable[..., WebSocketResource]]
+        ] = []
+        self._names: dict[str, str] = {}
+        self.name = name
+
+    def add_route(
+        self,
+        path: str,
+        resource: type[WebSocketResource] | typing.Callable[..., WebSocketResource],
+        *,
+        name: str | None = None,
+        args: tuple[typing.Any, ...] = (),
+        kwargs: dict[str, typing.Any] | None = None,
+    ) -> None:
+        """Register a WebSocketResource to handle ``path``."""
+        if kwargs is None:
+            kwargs = {}
+
+        def factory() -> WebSocketResource:
+            if isinstance(resource, type):
+                return resource(*args, **kwargs)
+            return resource(*args, **kwargs)
+
+        self._routes.append((path, _compile_template(path), factory))
+        if name:
+            self._names[name] = path
+
+    def url_for(self, name: str, **params: object) -> str:
+        """Return the URL path associated with ``name`` formatted with ``params``."""
+        template = self._names[name]
+        return template.format(**params)
+
+    async def on_websocket(
+        self, req: falcon.Request, ws: WebSocketLike
+    ) -> None:  # pragma: no cover - simple wrapper
+        """Dispatch the connection to the first matching route."""
+        prefix = getattr(req, "path_template", "").rstrip("/")
+        subpath = req.path[len(prefix) :] or "/"
+
+        for _template, pattern, factory in self._routes:
+            match = pattern.fullmatch(subpath)
+            if match:
+                resource = factory()
+                should_accept = await resource.on_connect(req, ws, **match.groupdict())
+                if not should_accept:
+                    await ws.close()
+                    return
+                await ws.accept()
+                return
+
+        raise falcon.HTTPNotFound

--- a/falcon_pachinko/unittests/test_router.py
+++ b/falcon_pachinko/unittests/test_router.py
@@ -155,6 +155,13 @@ def test_add_route_duplicate_name_and_path() -> None:
         router.add_route("/a/", DummyResource)
 
 
+def test_add_route_invalid_template() -> None:
+    """Empty parameter names should raise ``ValueError``."""
+    router = WebSocketRouter()
+    with pytest.raises(ValueError, match="Empty parameter name"):
+        router.add_route("/rooms/{}", DummyResource)
+
+
 @pytest.mark.asyncio
 async def test_overlapping_routes() -> None:
     """Ensure the first matching route is used when paths overlap."""

--- a/falcon_pachinko/unittests/test_router.py
+++ b/falcon_pachinko/unittests/test_router.py
@@ -115,7 +115,7 @@ async def test_on_connect_accepts_connection() -> None:
     async def accept() -> None:
         called["accepted"] = True
 
-    typing.cast(typing.Any, ws).accept = accept
+    typing.cast("typing.Any", ws).accept = accept
     req = type("Req", (), {"path": "/ok"})()
     await router.on_websocket(req, ws)
     assert called.get("accepted") is True

--- a/falcon_pachinko/unittests/test_router.py
+++ b/falcon_pachinko/unittests/test_router.py
@@ -1,0 +1,43 @@
+"""Tests for the WebSocketRouter class."""
+
+from __future__ import annotations
+
+import inspect
+import typing
+
+import pytest
+
+from falcon_pachinko import WebSocketResource, WebSocketRouter
+
+pytest_plugins = ["falcon_pachinko.unittests.test_app_install"]
+
+if typing.TYPE_CHECKING:
+    from falcon_pachinko.unittests.test_app_install import SupportsWebSocket
+
+
+class DummyResource(WebSocketResource):
+    """Capture connection parameters for testing."""
+
+    async def on_connect(self, req: object, ws: object, **params: object) -> bool:
+        """Record params and refuse the connection."""
+        self.params = params
+        return False
+
+
+def test_router_is_resource() -> None:
+    """Verify the router exposes a valid ``on_websocket`` responder."""
+    router = WebSocketRouter()
+    assert inspect.iscoroutinefunction(router.on_websocket)
+
+
+def test_deprecation_warnings(
+    dummy_app: SupportsWebSocket,
+    dummy_resource_cls: type[WebSocketResource],
+) -> None:
+    """Ensure legacy APIs emit :class:`DeprecationWarning`."""
+    with pytest.deprecated_call():
+        dummy_app.add_websocket_route("/ws", dummy_resource_cls)
+
+    dummy_app.add_websocket_route("/ws2", dummy_resource_cls)
+    with pytest.deprecated_call():
+        dummy_app.create_websocket_resource("/ws2")

--- a/falcon_pachinko/unittests/test_router.py
+++ b/falcon_pachinko/unittests/test_router.py
@@ -74,3 +74,20 @@ async def test_not_found_raises() -> None:
 
     with pytest.raises(falcon.HTTPNotFound):
         await router.on_websocket(req, DummyWS())
+
+
+def test_add_route_requires_callable() -> None:
+    """Non-callable resources must raise ``TypeError``."""
+    router = WebSocketRouter()
+    bad_resource = typing.cast("typing.Any", object())
+    with pytest.raises(TypeError):
+        router.add_route("/x", bad_resource)
+
+
+def test_url_for_unknown_route() -> None:
+    """Missing route names should raise a descriptive ``KeyError``."""
+    router = WebSocketRouter()
+    router.add_route("/x", DummyResource, name="x")
+
+    with pytest.raises(KeyError, match="no route registered"):
+        router.url_for("missing")

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -253,7 +253,7 @@ def _add_websocket_route(
         Keyword arguments for resource initialization
     """
     warnings.warn(
-        "add_websocket_route is deprecated; use WebSocketRouter.add_route instead",
+        "_add_websocket_route is deprecated; use WebSocketRouter.add_route instead",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -298,7 +298,7 @@ def _create_websocket_resource(self: typing.Any, path: str) -> WebSocketResource
         If no resource class is registered for ``path``
     """
     warnings.warn(
-        "create_websocket_resource is deprecated; use WebSocketRouter instead",
+        "_create_websocket_resource is deprecated; use WebSocketRouter instead",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import dataclasses as dc
 import typing
+import warnings
 from threading import Lock
 from types import MethodType
 
@@ -231,6 +232,9 @@ def _add_websocket_route(
 ) -> None:
     """Register ``resource_cls`` to handle connections for ``path``.
 
+    .. deprecated:: 0.1
+       Use :class:`falcon_pachinko.router.WebSocketRouter` instead.
+
     Any ``init_args`` or ``init_kwargs`` supplied are stored and applied when
     ``create_websocket_resource`` is called. This allows a single resource class
     to be configured differently across multiple routes.
@@ -248,6 +252,11 @@ def _add_websocket_route(
     **init_kwargs : object
         Keyword arguments for resource initialization
     """
+    warnings.warn(
+        "add_websocket_route is deprecated; use WebSocketRouter.add_route instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     _validate_route_path(path)
     _validate_resource_cls(resource_cls)
     with self._websocket_route_lock:
@@ -268,6 +277,9 @@ def _create_websocket_resource(self: typing.Any, path: str) -> WebSocketResource
     Initialization parameters provided to :func:`add_websocket_route` are
     forwarded to the resource constructor.
 
+    .. deprecated:: 0.1
+       Use :class:`falcon_pachinko.router.WebSocketRouter` instead.
+
     Parameters
     ----------
     self : typing.Any
@@ -285,6 +297,11 @@ def _create_websocket_resource(self: typing.Any, path: str) -> WebSocketResource
     ValueError
         If no resource class is registered for ``path``
     """
+    warnings.warn(
+        "create_websocket_resource is deprecated; use WebSocketRouter instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     with self._websocket_route_lock:
         routes = self._websocket_routes
         try:


### PR DESCRIPTION
## Summary
- deprecate `app.add_websocket_route` and `app.create_websocket_resource`
- introduce `WebSocketRouter` with `on_websocket` responder
- expose new router in package exports
- document completed roadmap tasks
- register fixtures across tests and add new coverage

## Testing
- `ruff format falcon_pachinko/router.py falcon_pachinko/unittests/test_router.py`
- `make lint`
- `make typecheck`
- `uv run pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68671c3c16188322a126f1343fbc871a

## Summary by Sourcery

Introduce a new WebSocketRouter to replace the legacy routing helpers, deprecate the old APIs with warnings, update documentation and build scripts, and add tests to cover the new router functionality.

New Features:
- Add WebSocketRouter class with add_route, url_for, and on_websocket methods for routing WebSocket connections

Enhancements:
- Deprecate legacy app.add_websocket_route and app.create_websocket_resource APIs with warnings and documentation updates
- Expose WebSocketRouter in package exports and update Makefile to enforce import linting

Documentation:
- Mark old routing helpers as deprecated in design docs and roadmap and add sequence and class diagrams for the new router

Tests:
- Add unit tests for WebSocketRouter including path matching, URL reversal, deprecation warnings, and connection acceptance behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new WebSocketRouter for pattern-based WebSocket routing in Falcon applications.

* **Documentation**
  * Updated documentation to deprecate legacy WebSocket routing APIs and added detailed diagrams and explanations for the new router.
  * Roadmap updated to reflect completed tasks for the new router.

* **Tests**
  * Added comprehensive tests for the new WebSocketRouter, including route matching, parameter handling, and error cases.

* **Chores**
  * Updated formatting and linting commands in the Makefile for improved code and documentation formatting.

* **Refactor**
  * Deprecated old WebSocket routing functions with warnings, guiding users to the new router.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->