### PR TITLE
Add mount-aware router

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,7 +24,7 @@ architectural change and underpins all subsequent features.
     `on_websocket(req, ws)` responder method to make it a valid, mountable
     Falcon resource.
 
-  - [ ] Implement the router's internal path-matching logic, leveraging
+  - [x] Implement the router's internal path-matching logic, leveraging
     `falcon.routing.compile_uri_template` to handle routes relative to its mount
     point.
 

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -83,8 +83,8 @@ class WebSocketRouter:
 
     def mount(self, prefix: str) -> None:
         """Compile stored routes with the given mount ``prefix``."""
-        if not prefix or not prefix.startswith("/"):
-            msg = "prefix must be a non-empty string starting with '/'"
+        if prefix and not prefix.startswith("/"):
+            msg = "prefix must start with '/'"
             raise ValueError(msg)
 
         canonical = prefix.rstrip("/") or "/"

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -85,7 +85,13 @@ class WebSocketRouter:
         canonical: str,
         factory: typing.Callable[..., WebSocketResource],
     ) -> None:
-        """Compile ``canonical`` with the mount prefix and store it."""
+        """Compile ``canonical`` with the mount prefix and store it.
+
+        This helper mutates :attr:`_routes` and therefore assumes the caller
+        already holds :attr:`_mount_lock`. The router relies on this lock to
+        guard all mount-related state, preventing race conditions when routes
+        are added concurrently with mounting.
+        """
         base = self._mount_prefix.rstrip("/")
         full = f"{base}{canonical}"
         pattern = compile_uri_template(full)

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -20,7 +20,7 @@ if typing.TYPE_CHECKING:
     from .resource import WebSocketLike, WebSocketResource
 
 
-def _compile_uri_template(template: str) -> re.Pattern[str]:
+def compile_uri_template(template: str) -> re.Pattern[str]:
     """Compile a simple URI template into a regex pattern."""
 
     def replace_param(match: re.Match[str]) -> str:
@@ -78,7 +78,7 @@ class WebSocketRouter:
         """Compile ``canonical`` with the mount prefix and store it."""
         base = self._mount_prefix.rstrip("/")
         full = f"{base}{canonical}"
-        pattern = _compile_uri_template(full)
+        pattern = compile_uri_template(full)
         self._routes.append((pattern, factory))
 
     def mount(self, prefix: str) -> None:
@@ -126,7 +126,7 @@ class WebSocketRouter:
 
         # Compile once to validate the template. The prefix is applied lazily
         # upon the first request since it may not yet be known at this point.
-        _compile_uri_template(canonical)
+        compile_uri_template(canonical)
 
         factory = functools.partial(resource, *args, **kwargs)
 

--- a/falcon_pachinko/unittests/test_router.py
+++ b/falcon_pachinko/unittests/test_router.py
@@ -160,6 +160,19 @@ def test_add_route_duplicate_name_and_path() -> None:
         router.add_route("/a/", DummyResource)
 
 
+def test_add_route_duplicates_after_mount() -> None:
+    """Adding duplicates after mounting should raise ``ValueError``."""
+    router = WebSocketRouter()
+    router.add_route("/dup", DummyResource, name="dup")
+    router.mount("/api")
+
+    with pytest.raises(ValueError, match="already registered"):
+        router.add_route("/dup", DummyResource, name="other")
+
+    with pytest.raises(ValueError, match="already registered"):
+        router.add_route("/other", DummyResource, name="dup")
+
+
 def test_add_route_invalid_template() -> None:
     """Empty parameter names should raise ``ValueError``."""
     router = WebSocketRouter()

--- a/falcon_pachinko/unittests/test_router.py
+++ b/falcon_pachinko/unittests/test_router.py
@@ -203,8 +203,10 @@ async def test_mount_with_empty_vs_slash_prefix() -> None:
     await router_slash.on_websocket(req, DummyWS())
 
     router_empty = WebSocketRouter()
-    with pytest.raises(ValueError, match="prefix"):
-        router_empty.mount("")
+    router_empty.add_route("/y", AcceptingResource)
+    router_empty.mount("")
+    req_empty = type("Req", (), {"path": "/y", "path_template": ""})()
+    await router_empty.on_websocket(req_empty, DummyWS())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- compile WebSocket route patterns with the router's mount prefix
- validate templates when routes are added
- mark routing task complete in the roadmap

## Testing
- `ruff format falcon_pachinko/router.py`
- `ruff check --select I --fix falcon_pachinko/router.py`
- `make lint`
- `make typecheck`
- `uv run pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68685cab7a8c83229b252ecafa6ab9d6

## Summary by Sourcery

Introduce mount-aware routing for WebSocketRouter by adding a mount() API that compiles routes with a configurable prefix, validate URI templates at registration, and enforce mount-point matching in on_websocket.

New Features:
- Add a mount() method to register a URI prefix for all routes.
- Compile WebSocket route patterns relative to the configured mount prefix.
- Validate URI templates when routes are added.

Enhancements:
- Refactor route storage into raw and compiled dataclasses protected by a threading lock.
- Adjust on_websocket logic to enforce mount prefix checks and full-path matching.
- Rename the internal _compile_template function to compile_uri_template for clarity.

Documentation:
- Update the roadmap to mark the router’s internal path-matching logic as complete.

Tests:
- Add tests for mount behavior including pre- and post-mount route registration, duplicate detection, prefix mismatch, and empty vs slash prefixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to mark the router's internal path-matching logic task as completed.

* **Bug Fixes**
  * Improved duplicate route detection to correctly compare canonical paths.

* **Refactor**
  * Introduced explicit mounting of routers with path prefixes, separating route registration from compilation.
  * Adjusted route matching to compare full request paths against compiled patterns with mount prefixes.
  * Added thread safety around router mounting.
  * Updated tests to ensure route mounting is consistently applied and verified.
  * Added new tests for mounting behavior, including error handling for invalid or repeated mounts and duplicate routes after mounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->