### PR TITLE
Add WebSocketRouter routing options

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,25 +28,25 @@ architectural change and underpins all subsequent features.
     `falcon.routing.compile_uri_template` to handle routes relative to its mount
     point.
 
-- [ ] **Implement the** `WebSocketRouter.add_route()` **API.**
+- [x] **Implement the** `WebSocketRouter.add_route()` **API.**
 
-  - [ ] The method must accept a relative path, a name for URL reversal, and the
+  - [x] The method must accept a relative path, a name for URL reversal, and the
     target resource.
 
-  - [ ] Add support for both `WebSocketResource` classes and callable factories
+  - [x] Add support for both `WebSocketResource` classes and callable factories
     as route targets, mirroring Falcon's HTTP routing flexibility.
 
-  - [ ] Add support for passing `*args` and `**kwargs` during route definition
+  - [x] Add support for passing `*args` and `**kwargs` during route definition
     for resource initialization.
 
-  - [ ] Implement `router.url_for(name, **params)` for reverse URL generation.
+  - [x] Implement `router.url_for(name, **params)` for reverse URL generation.
 
-- [ ] **Update Core Tests.**
+- [x] **Update Core Tests.**
 
-  - [ ] Write new integration tests to verify that a `WebSocketRouter` can be
+  - [x] Write new integration tests to verify that a `WebSocketRouter` can be
     mounted on a Falcon `App`.
 
-  - [ ] Test that connections to routes defined on the router correctly
+  - [x] Test that connections to routes defined on the router correctly
     instantiate the associated resource with the correct path parameters and
     initialization arguments.
 

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -192,6 +192,7 @@ class _HandlesMessageDescriptor:
         """
         self.message_type = message_type
         self.func = func
+        self.payload_type = _get_payload_type(func)
         functools.update_wrapper(self, func)  # pyright: ignore[reportArgumentType]
         self.owner: type | None = None
         self.name: str | None = None
@@ -235,12 +236,10 @@ class _HandlesMessageDescriptor:
             )
             raise RuntimeError(msg)
 
-        payload_type = _get_payload_type(self.func)
-
         typed_owner.add_handler(
             self.message_type,
             self.func,
-            payload_type=payload_type,
+            payload_type=self.payload_type,
         )
 
     def __get__(


### PR DESCRIPTION
## Summary
- test WebSocketRouter.add_route with init args and factory targets
- support signature validation before descriptor registration
- demonstrate mounting router on a Falcon app

## Testing
- `MDFORMAT_ALL=true make fmt`
- `make lint`
- `make typecheck`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6869b52ff534832292bf7544affe64c5

## Summary by Sourcery

Add routing options to WebSocketRouter by supporting init args/kwargs, factory targets, and app mounting; and extract payload_type at initialization to validate signatures earlier.

New Features:
- Support passing init args and kwargs to WebSocketRouter.add_route for parameterized resources
- Allow using callable factories as WebSocket route targets
- Enable mounting WebSocketRouter instances on a Falcon ASGI App

Enhancements:
- Move payload_type extraction to resource descriptor initialization to enable signature validation before registration

Tests:
- Add tests for init args/kwargs forwarding, factory targets, and router mounting on Falcon App

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new tests to verify correct handling of route initialization arguments and factory functions in WebSocket routing.
  * Introduced tests to ensure proper parameter passing and WebSocket request dispatching when the router is mounted on an application.
* **Chores**
  * Improved internal efficiency by optimizing message payload type handling.
* **Documentation**
  * Updated roadmap to reflect completion of WebSocket routing features and core test enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->