### PR TITLE
Add router path resolution diagram

### DIFF
--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -752,6 +752,26 @@ The `WebSocketRouter` must resolve these composite paths. A trie (prefix tree) i
 
 A critical aspect is **context passing**. The router must facilitate passing state from parent to child. A robust implementation would involve the router instantiating the entire resource chain, allowing parent resources to pass relevant state (or `self`) into the constructors of their children.
 
+```mermaid
+sequenceDiagram
+    participant Client
+    participant FalconRequest as Falcon Request
+    participant WebSocketRouter
+    participant ResourceFactory
+
+    Client->>FalconRequest: Initiates WebSocket request
+    FalconRequest->>WebSocketRouter: on_websocket(req, ws)
+    WebSocketRouter->>WebSocketRouter: Check req.path_template == _mount_prefix
+    WebSocketRouter->>WebSocketRouter: Match full request path against compiled routes
+    alt Match found
+        WebSocketRouter->>ResourceFactory: Instantiate resource
+        ResourceFactory-->>WebSocketRouter: Resource instance
+        WebSocketRouter->>ResourceFactory: Call resource handler
+    else No match
+        WebSocketRouter->>FalconRequest: Raise 404
+    end
+```
+
 ### 5.3. High-Performance Schema-Driven Dispatch with `msgspec`
 
 This proposal elevates the dispatch mechanism using `msgspec` and its support for tagged unions. This moves from simple dispatch to a declarative, schema-driven approach.


### PR DESCRIPTION
## Summary
- document WebSocketRouter path resolution

## Testing
- `make markdownlint` *(fails: line length in existing docs)*
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_6869b85c66f48322b60bed602abec3b2

## Summary by Sourcery

Documentation:
- Add a sequence diagram to the design docs showing WebSocket request flow through the router, including path matching, resource instantiation, handler invocation, and 404 handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Mermaid sequence diagram to the design document, illustrating the flow of a WebSocket connection through the proposed routing system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->