### PR TITLE
Fix API overview table

### DIFF
--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -566,23 +566,19 @@ The following table summarizes the key components of the proposed
 Falcon-Pachinko API and their analogies to Falcon's HTTP mechanisms, where
 applicable. This serves as a quick reference to understand the main abstractions
 and their intended use. This API structure is designed to be both powerful
-enough for complex | Component | Key Elements | Purpose | Falcon Analogy | |
---------- | ------------ | ------- | -------------- | | Application Setup |
-`falcon_pachinko.install(app)` | Initializes shared WebSocket components such as
-the connection manager. | App-level extensions | | Route Definition |
-`app.add_websocket_route()` and `WebSocketRouter.add_route()` | Maps a URI path
-to a `WebSocketResource`. | `app.add_route()` | | Resource Class |
-`falcon_pachinko.WebSocketResource` | Handles connections and messages for a
-given route. | Falcon HTTP `Resource` | | Connection Lifecycle | `on_connect()`,
-`on_disconnect()` | Setup and teardown hooks for each connection. |
-Request/response middleware | | Message Handling (Typed) | `@handles_message()`
-and `on_{type}` | Routes incoming JSON messages by type. | `on_get`, `on_post`,
-etc. | | Message Handling (Generic) | `on_unhandled()` | Fallback for
-unrecognized or non-JSON messages. | N/A | | Background Worker Integration |
-`WorkerController`, `@app.lifespan` | Manages long-running tasks within the ASGI
-lifecycle. | Custom patterns | | Connection Management (Global) |
-`app.ws_connection_manager` | Tracks connections and enables broadcasting. | N/A
-| applications and intuitive for developers accustomed to Falcon. |
+enough for complex applications and intuitive for developers accustomed to
+Falcon.
+
+| Component | Key Elements | Purpose | Falcon Analogy |
+| --------- | ------------ | ------- | -------------- |
+| Application Setup | `falcon_pachinko.install(app)` | Initializes shared WebSocket components such as the connection manager. | App-level extensions |
+| Route Definition | `app.add_websocket_route()` and `WebSocketRouter.add_route()` | Maps a URI path to a `WebSocketResource`. | `app.add_route()` |
+| Resource Class | `falcon_pachinko.WebSocketResource` | Handles connections and messages for a given route. | Falcon HTTP `Resource` |
+| Connection Lifecycle | `on_connect()`, `on_disconnect()` | Setup and teardown hooks for each connection. | Request/response middleware |
+| Message Handling (Typed) | `@handles_message()` and `on_{type}` | Routes incoming JSON messages by type. | `on_get`, `on_post`, etc. |
+| Message Handling (Generic) | `on_unhandled()` | Fallback for unrecognized or non-JSON messages. | N/A |
+| Background Worker Integration | `WorkerController`, `@app.lifespan` | Manages long-running tasks within the ASGI lifecycle. | Custom patterns |
+| Connection Management (Global) | `app.ws_connection_manager` | Tracks connections and enables broadcasting. | N/A |
 
 ## 4. Illustrative Usecase: Real-time Chat Application
 


### PR DESCRIPTION
## Summary
- repair table formatting in the websocket extension design doc

## Testing
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_6869ce4ea4b083229b2c031141b3addc

## Summary by Sourcery

Documentation:
- Repair the API overview table formatting in the websocket extension design doc to use standard markdown table syntax.