### PR TITLE
Add schema-driven dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ for the full design rationale.
   lifecycle hooks.
 - Message payloads are parsed into `msgspec.Struct` classes for speed and type
   safety.
-- `@handles_message("type")` dispatches incoming JSON messages to specific
-  handler methods.
+- Define a `schema` union of tagged `msgspec.Struct` types to enable automatic
+  dispatch based on the message tag.
+- Use the canonical `@handles_message("type")` decorator to register message
+  handlers.
 - `WebSocketConnectionManager` tracks connections, manages rooms, and lets
   workers broadcast messages.
 - Background tasks register via `app.add_websocket_worker` and interact with the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -57,13 +57,13 @@ composable patterns.
 
 - [ ] **Integrate** `msgspec` **for Schema-Driven Dispatch.**
 
-  - [ ] Refactor the `WebSocketResource` dispatch loop to prioritize the
+  - [x] Refactor the `WebSocketResource` dispatch loop to prioritize the
     `schema` attribute (a `msgspec` tagged union).
 
-  - [ ] Implement the logic to decode messages against the schema and route to
+  - [x] Implement the logic to decode messages against the schema and route to
     handlers based on the message tag.
 
-  - [ ] Make the `@handles_message("type")` decorator the canonical, preferred
+  - [x] Make the `@handles_message("type")` decorator the canonical, preferred
     way to register a handler.
 
   - [ ] Implement the `on_{tag}` naming convention as a best-effort convenience,

--- a/falcon_pachinko/unittests/test_schema_dispatch.py
+++ b/falcon_pachinko/unittests/test_schema_dispatch.py
@@ -73,3 +73,18 @@ async def test_schema_decode_error_calls_fallback() -> None:
     r = SchemaResource()
     await r.dispatch(DummyWS(), b"not json")
     assert r.events == [("raw", b"not json")]
+
+
+def test_invalid_schema_type_raises() -> None:
+    """Only tagged msgspec.Struct types are allowed in ``schema``."""
+
+    class Good(msgspec.Struct, tag="good"):
+        pass
+
+    class Bad:
+        pass
+
+    with pytest.raises(TypeError):
+
+        class BadResource(WebSocketResource):
+            schema = Good | Bad

--- a/falcon_pachinko/unittests/test_schema_dispatch.py
+++ b/falcon_pachinko/unittests/test_schema_dispatch.py
@@ -1,0 +1,75 @@
+"""Tests for schema-driven dispatch using msgspec tagged unions."""
+
+import typing
+
+import msgspec
+import msgspec.json as msgspec_json
+import pytest
+
+from falcon_pachinko import WebSocketLike, WebSocketResource, handles_message
+from falcon_pachinko.unittests.helpers import DummyWS
+
+
+class Join(msgspec.Struct, tag="join"):
+    """Message structure for join events."""
+
+    room: str
+
+
+class Leave(msgspec.Struct, tag="leave"):
+    """Message structure for leave events."""
+
+    room: str
+
+
+MessageUnion = Join | Leave
+
+
+class SchemaResource(WebSocketResource):
+    """Resource using a schema for automatic message dispatch."""
+
+    schema = MessageUnion
+
+    def __init__(self) -> None:
+        """Initialize with an empty events list."""
+        self.events: list[tuple[str, typing.Any]] = []
+
+    @handles_message("join")
+    async def handle_join(self, ws: WebSocketLike, payload: Join) -> None:
+        """Record join events."""
+        self.events.append(("join", payload.room))
+
+    @handles_message("leave")
+    async def handle_leave(self, ws: WebSocketLike, payload: Leave) -> None:
+        """Record leave events."""
+        self.events.append(("leave", payload.room))
+
+    async def on_message(self, ws: WebSocketLike, message: str | bytes) -> None:
+        """Record fallback messages."""
+        self.events.append(("raw", message))
+
+
+@pytest.mark.asyncio
+async def test_schema_dispatch_to_handlers() -> None:
+    """Messages matching the schema are routed to decorated handlers."""
+    r = SchemaResource()
+    await r.dispatch(DummyWS(), msgspec_json.encode(Join(room="a")))
+    await r.dispatch(DummyWS(), msgspec_json.encode(Leave(room="b")))
+    assert r.events == [("join", "a"), ("leave", "b")]
+
+
+@pytest.mark.asyncio
+async def test_schema_unknown_tag_calls_fallback() -> None:
+    """Unknown tags invoke the fallback handler with the raw message."""
+    r = SchemaResource()
+    raw = msgspec_json.encode({"type": "oops", "room": "x"})
+    await r.dispatch(DummyWS(), raw)
+    assert r.events == [("raw", raw)]
+
+
+@pytest.mark.asyncio
+async def test_schema_decode_error_calls_fallback() -> None:
+    """Decode failures also trigger the fallback handler."""
+    r = SchemaResource()
+    await r.dispatch(DummyWS(), b"not json")
+    assert r.events == [("raw", b"not json")]


### PR DESCRIPTION
## Summary
- integrate `msgspec` tagged union schema for dispatch
- document canonical `@handles_message` decorator in README
- mark roadmap tasks complete
- add unit tests for schema-driven dispatch

## Testing
- `make lint`
- `make typecheck`
- `uv run pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_686c4dba01588322b52c604cdbd5f601

## Summary by Sourcery

Integrate msgspec tagged-union schemas into WebSocketResource to enable high-performance, schema-driven dispatch with validation, update documentation accordingly, and add comprehensive tests.

New Features:
- Allow WebSocketResource subclasses to define a tagged-union `schema` for automatic message routing
- Implement schema-driven message decoding and dispatch based on msgspec tagged unions

Enhancements:
- Refactor dispatch logic into separate schema and envelope methods
- Initialize and validate schema registry to map struct types to handlers
- Enforce msgspec.Struct types with defined tags in the schema attribute

Documentation:
- Update README to document the canonical `@handles_message` decorator and schema-driven dispatch
- Mark related tasks as complete in the project roadmap

Tests:
- Add unit tests covering schema-driven dispatch, unknown tags fallback, decode errors, and schema validation

Chores:
- Mark roadmap entries for schema-driven dispatch as completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced WebSocket message handling to support schema-driven dispatch using tagged message types, allowing for automatic routing of messages to their respective handlers.
* **Documentation**
  * Expanded documentation to clarify the use of schema unions and handler registration for message dispatching.
  * Updated roadmap to mark schema-driven dispatch tasks as completed.
* **Tests**
  * Added tests to verify correct dispatching of messages based on schema, including handling of unknown tags and decoding errors.
  * Added validation to ensure only tagged message types are allowed in schema definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->