### PR TITLE
Raise error on duplicate payload types

### DIFF
--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -15,7 +15,14 @@ if typing.TYPE_CHECKING:
     import falcon
 
 
-_DUPLICATE_PAYLOAD_TYPE_MSG = "Duplicate payload type in handlers"
+def _duplicate_payload_type_msg(
+    payload_type: type, handler_name: str | None = None
+) -> str:
+    """Return a detailed error message for duplicate payload types."""
+    msg = f"Duplicate payload type in handlers: {payload_type!r}"
+    if handler_name:
+        msg += f" (handler: {handler_name})"
+    return msg
 
 
 class HandlerSignatureError(TypeError):
@@ -409,7 +416,9 @@ class WebSocketResource:
 
             existing = cls._struct_handlers.get(payload_type)
             if existing is not None:
-                raise ValueError(_DUPLICATE_PAYLOAD_TYPE_MSG)
+                raise ValueError(
+                    _duplicate_payload_type_msg(payload_type, handler.__qualname__)
+                )
             cls._struct_handlers[payload_type] = (handler, payload_type)
 
     async def on_connect(

--- a/falcon_pachinko/unittests/test_schema_dispatch.py
+++ b/falcon_pachinko/unittests/test_schema_dispatch.py
@@ -96,7 +96,7 @@ def test_duplicate_payload_type_raises() -> None:
     class Payload(msgspec.Struct, tag="dup"):
         val: int
 
-    with pytest.raises(ValueError, match="Duplicate payload type"):
+    with pytest.raises(ValueError, match="Duplicate payload type") as exc:
 
         class BadResource(WebSocketResource):
             schema = Payload
@@ -106,3 +106,6 @@ def test_duplicate_payload_type_raises() -> None:
 
             @handles_message("b")
             async def h2(self, ws: WebSocketLike, payload: Payload) -> None: ...
+
+    assert "Payload" in str(exc.value)
+    assert "BadResource.h2" in str(exc.value)

--- a/falcon_pachinko/unittests/test_schema_dispatch.py
+++ b/falcon_pachinko/unittests/test_schema_dispatch.py
@@ -88,3 +88,21 @@ def test_invalid_schema_type_raises() -> None:
 
         class BadResource(WebSocketResource):
             schema = Good | Bad
+
+
+def test_duplicate_payload_type_raises() -> None:
+    """Handlers with the same payload type should not be allowed."""
+
+    class Payload(msgspec.Struct, tag="dup"):
+        val: int
+
+    with pytest.raises(ValueError, match="Duplicate payload type"):
+
+        class BadResource(WebSocketResource):
+            schema = Payload
+
+            @handles_message("a")
+            async def h1(self, ws: WebSocketLike, payload: Payload) -> None: ...
+
+            @handles_message("b")
+            async def h2(self, ws: WebSocketLike, payload: Payload) -> None: ...


### PR DESCRIPTION
## Summary
- detect duplicate payload classes when building struct handler map
- test error path for duplicate payload types

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686e150ab99c832295da8dd14f3bc850

## Summary by Sourcery

Prevent duplicate payload struct types in WebSocketResource handlers by raising a ValueError and introduce a test to cover this error path.

Bug Fixes:
- Disallow registering multiple handlers for the same payload struct type by raising an error during handler map construction

Enhancements:
- Add a specific error message constant for duplicate payload types

Tests:
- Add a test to verify that duplicate payload type registration raises a ValueError

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling by raising a clear error when duplicate payload types are detected in message handlers.

* **Tests**
  * Added a test to ensure that defining multiple handlers for the same payload type raises an appropriate error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->