### PR TITLE
Implement on_tag dispatch helper

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -66,7 +66,7 @@ composable patterns.
   - [x] Make the `@handles_message("type")` decorator the canonical, preferred
     way to register a handler.
 
-  - [ ] Implement the `on_{tag}` naming convention as a best-effort convenience,
+  - [x] Implement the `on_{tag}` naming convention as a best-effort convenience,
     including the `CamelCase` to `snake_case` conversion.
 
   - [ ] Document `msgspec`'s default strictness (no extra fields) and expose a

--- a/falcon_pachinko/unittests/test_websocket_resource.py
+++ b/falcon_pachinko/unittests/test_websocket_resource.py
@@ -122,6 +122,35 @@ async def raw_handler(self: RawResource, ws: WebSocketLike, payload: object) -> 
 RawResource.add_handler("raw", raw_handler, payload_type=None)
 
 
+class ConventionalResource(WebSocketResource):
+    """Resource used to test ``on_{tag}`` dispatch."""
+
+    def __init__(self) -> None:
+        self.seen: list[typing.Any] = []
+
+    async def on_echo(self, ws: WebSocketLike, payload: object) -> None:
+        """Record ``payload`` from ``echo`` messages."""
+        self.seen.append(payload)
+
+
+class CamelResource(WebSocketResource):
+    """Resource testing CamelCase tag conversion."""
+
+    class SendMessage(msgspec.Struct, tag="sendMessage"):
+        """Payload for a send message."""
+
+        text: str
+
+    schema = SendMessage
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def on_send_message(self, ws: WebSocketLike, payload: SendMessage) -> None:
+        """Record ``payload`` text from ``sendMessage`` messages."""
+        self.messages.append(payload.text)
+
+
 @pytest.mark.asyncio
 async def test_dispatch_calls_registered_handler() -> None:
     """Test that dispatching a message with a registered type calls the handler."""
@@ -197,3 +226,21 @@ async def test_invalid_payload_calls_fallback() -> None:
     await r.dispatch(DummyWS(), raw)
     assert r.fallback == [raw]
     assert not r.seen
+
+
+@pytest.mark.asyncio
+async def test_on_tag_dispatch_envelope() -> None:
+    """Messages with matching ``on_{tag}`` handlers are dispatched."""
+    r = ConventionalResource()
+    raw = msgspec_json.encode({"type": "echo", "payload": {"x": 1}})
+    await r.dispatch(DummyWS(), raw)
+    assert r.seen == [{"x": 1}]
+
+
+@pytest.mark.asyncio
+async def test_on_tag_camel_case() -> None:
+    """CamelCase tags are converted to snake_case."""
+    r = CamelResource()
+    raw = msgspec_json.encode(CamelResource.SendMessage(text="hi"))
+    await r.dispatch(DummyWS(), raw)
+    assert r.messages == ["hi"]


### PR DESCRIPTION
## Summary
- implement `on_{tag}` naming convention with camelCase conversion
- test envelope & schema dispatch using conventional handlers
- mark roadmap item as complete

## Testing
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687196f4268c83228877d71334dcfdfa