### PR TITLE
Add strict parameter to handles_message

### DIFF
--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -296,7 +296,8 @@ logic.
     when the WebSocket connection is closed, either by the client or the
     server. `close_code` provides the WebSocket close code.
 
-  - `async def on_unhandled(self, ws: WebSocketLike, message: Union[str, bytes])`
+  - `async def on_unhandled(self, ws: WebSocketLike, message: Union[str,
+    bytes])`
     :
     A fallback handler for messages that are not dispatched by the more
     specific message handlers. This can be used for raw text/binary data or
@@ -361,10 +362,14 @@ avoids a monolithic receive loop with extensive conditional logic.
   handler's `payload` parameter is type-annotated with a `msgspec.Struct`, the
   library will perform high-performance validation and deserialization. By
   default, `msgspec` forbids extra fields in the payload. This strictness is a
-  feature for ensuring contract adherence. The library will document this
-  behaviour clearly and may expose an option like
-  `@handles_message("type", strict=False)` to relax this for specific handlers
-  if required.
+  feature for ensuring contract adherence. Falcon-Pachinko exposes a ``strict``
+  option on ``@handles_message`` to relax this behaviour when needed:
+
+  ```python
+  @handles_message("type", strict=False)
+  async def on_type(self, ws, payload: SomeStruct) -> None:
+      ...
+  ```
 
 #### 3.6.1. Descriptor Implementation of `handles_message`
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -69,7 +69,7 @@ composable patterns.
   - [x] Implement the `on_{tag}` naming convention as a best-effort convenience,
     including the `CamelCase` to `snake_case` conversion.
 
-  - [ ] Document `msgspec`'s default strictness (no extra fields) and expose a
+  - [x] Document `msgspec`'s default strictness (no extra fields) and expose a
     `strict=False` option on the decorator.
 
 - [ ] **Refine Resource API and State Management.**

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -36,9 +36,12 @@ def _duplicate_payload_type_msg(
     return msg
 
 
-def _raise_unknown_fields() -> None:
+def _raise_unknown_fields(extra_fields: set[str], payload: dict | None = None) -> None:
     """Raise a validation error for unknown fields."""
-    raise msgspec.ValidationError
+    details = f"Unknown fields in payload: {sorted(extra_fields)}"
+    if payload is not None:
+        details += f" -> {payload}"
+    raise msgspec.ValidationError(details)
 
 
 def _to_snake_case(name: str) -> str:
@@ -610,7 +613,7 @@ class WebSocketResource:
                     }
                     extra = set(payload) - allowed
                     if extra:
-                        _raise_unknown_fields()
+                        _raise_unknown_fields(extra, payload)
 
                 payload = typing.cast(
                     "typing.Any",

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -474,7 +474,6 @@ class WebSocketResource:
 
         return HandlerInfo(typing.cast("Handler", func), payload_type, strict=True)
 
-
     def _requires_strict_validation(
         self, payload: object, payload_type: type, *, strict: bool
     ) -> bool:

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -491,13 +491,14 @@ class WebSocketResource:
         self, payload: object, payload_type: type, *, strict: bool
     ) -> None:
         """Raise if ``payload`` contains unknown fields in strict mode."""
-        if strict and isinstance(payload, dict) and issubclass(
-            payload_type, msgspec.Struct
+        if (
+            strict
+            and isinstance(payload, dict)
+            and issubclass(payload_type, msgspec.Struct)
         ):
             info = msgspec_inspect.type_info(payload_type)
             allowed = {
-                f.name
-                for f in typing.cast("msgspec_inspect.StructType", info).fields
+                f.name for f in typing.cast("msgspec_inspect.StructType", info).fields
             }
             extra = set(payload) - allowed
             if extra:

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -474,16 +474,6 @@ class WebSocketResource:
 
         return HandlerInfo(typing.cast("Handler", func), payload_type, strict=True)
 
-    def _should_validate_extra_fields(
-        self,
-        handler_info: HandlerInfo,
-        payload: object,
-        payload_type: type,
-    ) -> bool:
-        """Return ``True`` if strict validation of extra fields is required."""
-        return self._requires_strict_validation(
-            payload, payload_type, strict=handler_info.strict
-        )
 
     def _requires_strict_validation(
         self, payload: object, payload_type: type, *, strict: bool
@@ -637,10 +627,8 @@ class WebSocketResource:
         payload_type = handler_info.payload_type
         if payload_type is not None and payload is not None:
             try:
-                if self._should_validate_extra_fields(
-                    handler_info,
-                    payload,
-                    payload_type,
+                if self._requires_strict_validation(
+                    payload, payload_type, strict=handler_info.strict
                 ):
                     self._validate_strict_payload(
                         payload, payload_type, strict=handler_info.strict

--- a/falcon_pachinko/unittests/test_handles_message.py
+++ b/falcon_pachinko/unittests/test_handles_message.py
@@ -231,4 +231,4 @@ def test_unresolved_annotation_is_ignored() -> None:
             """
             ...
 
-    assert UnknownAnnoResource.handlers["unknown"][1] is None
+    assert UnknownAnnoResource.handlers["unknown"].payload_type is None


### PR DESCRIPTION
## Summary
- document `strict` handling in design docs
- mark roadmap item done
- add `strict` option to `handles_message` decorator
- validate extra fields when `strict=True`
- add tests for strict payload handling

## Testing
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687ae0dc3b0883228c08657b681d82b6

## Summary by Sourcery

Add a strict validation option to message handlers, enforce it by default, refactor internal handler metadata to include the strict flag, update documentation, and add tests for strict and lenient modes.

New Features:
- Expose strict parameter on handles_message decorator to control payload validation
- Enforce strict payload validation by default to reject messages with extra fields
- Allow lenient mode to ignore extra payload fields

Enhancements:
- Refactor handler metadata to include strict flag in HandlerInfo and streamline dispatch logic

Documentation:
- Document strict payload handling option in design docs and update roadmap

Tests:
- Add unit tests for strict versus lenient payload handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable strictness for WebSocket message payload validation, allowing handlers to reject or accept extra fields in incoming messages.
  * Introduced an option to disable strict validation for specific handlers, enabling more flexible payload processing.

* **Documentation**
  * Updated documentation to clarify the strictness option for message handlers and provided usage examples.
  * Marked the relevant roadmap item as completed.

* **Tests**
  * Added tests to verify strict and lenient payload validation behavior for WebSocket message handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->