### PR TITLE
Update msgspec.json alias to msjson

### DIFF
--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -11,7 +11,7 @@ import typing
 
 import msgspec
 import msgspec.inspect as msgspec_inspect
-import msgspec.json as msgspec_json
+import msgspec.json as msjson
 
 if typing.TYPE_CHECKING:
     import falcon
@@ -617,7 +617,7 @@ class WebSocketResource:
     async def _dispatch_with_schema(self, ws: WebSocketLike, raw: str | bytes) -> None:
         """Decode and dispatch ``raw`` using :attr:`schema`."""
         try:
-            message = msgspec_json.decode(raw, type=self.schema)
+            message = msjson.decode(raw, type=self.schema)
         except (msgspec.DecodeError, msgspec.ValidationError):
             await self.on_message(ws, raw)
             return
@@ -672,7 +672,7 @@ class WebSocketResource:
     ) -> None:
         """Decode and dispatch ``raw`` using the envelope format."""
         try:
-            envelope = msgspec_json.decode(raw, type=_Envelope)
+            envelope = msjson.decode(raw, type=_Envelope)
         except msgspec.DecodeError:
             await self.on_message(ws, raw)
             return

--- a/falcon_pachinko/unittests/test_handles_message.py
+++ b/falcon_pachinko/unittests/test_handles_message.py
@@ -14,7 +14,7 @@ cover various scenarios including:
 from __future__ import annotations
 
 import msgspec
-import msgspec.json as msgspec_json
+import msgspec.json as msjson
 import pytest
 
 from falcon_pachinko import WebSocketLike, WebSocketResource, handles_message
@@ -58,7 +58,7 @@ async def test_decorator_registers_handler() -> None:
     3. The payload is properly deserialized and passed to the handler
     """
     r = DecoratedResource()
-    raw = msgspec_json.encode({"type": "ping", "payload": {"text": "hi"}})
+    raw = msjson.encode({"type": "ping", "payload": {"text": "hi"}})
     await r.dispatch(DummyWS(), raw)
     assert r.seen == ["hi"]
 
@@ -184,8 +184,8 @@ async def test_handlers_inherited() -> None:
     4. Method overrides without decoration still work as handlers
     """
     r = ChildResource()
-    await r.dispatch(DummyWS(), msgspec_json.encode({"type": "parent"}))
-    await r.dispatch(DummyWS(), msgspec_json.encode({"type": "child"}))
+    await r.dispatch(DummyWS(), msjson.encode({"type": "parent"}))
+    await r.dispatch(DummyWS(), msjson.encode({"type": "child"}))
     assert r.invoked == ["parent", "child"]
 
 
@@ -198,7 +198,7 @@ async def test_decorated_override() -> None:
     precedence over the parent's handler.
     """
     r = DecoratedOverride()
-    await r.dispatch(DummyWS(), msgspec_json.encode({"type": "parent"}))
+    await r.dispatch(DummyWS(), msjson.encode({"type": "parent"}))
     assert r.invoked == "decorated"
 
 

--- a/falcon_pachinko/unittests/test_schema_dispatch.py
+++ b/falcon_pachinko/unittests/test_schema_dispatch.py
@@ -3,7 +3,7 @@
 import typing
 
 import msgspec
-import msgspec.json as msgspec_json
+import msgspec.json as msjson
 import pytest
 
 from falcon_pachinko import WebSocketLike, WebSocketResource, handles_message
@@ -53,8 +53,8 @@ class SchemaResource(WebSocketResource):
 async def test_schema_dispatch_to_handlers() -> None:
     """Messages matching the schema are routed to decorated handlers."""
     r = SchemaResource()
-    await r.dispatch(DummyWS(), msgspec_json.encode(Join(room="a")))
-    await r.dispatch(DummyWS(), msgspec_json.encode(Leave(room="b")))
+    await r.dispatch(DummyWS(), msjson.encode(Join(room="a")))
+    await r.dispatch(DummyWS(), msjson.encode(Leave(room="b")))
     assert r.events == [("join", "a"), ("leave", "b")]
 
 
@@ -62,7 +62,7 @@ async def test_schema_dispatch_to_handlers() -> None:
 async def test_schema_unknown_tag_calls_fallback() -> None:
     """Unknown tags invoke the fallback handler with the raw message."""
     r = SchemaResource()
-    raw = msgspec_json.encode({"type": "oops", "room": "x"})
+    raw = msjson.encode({"type": "oops", "room": "x"})
     await r.dispatch(DummyWS(), raw)
     assert r.events == [("raw", raw)]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ banned-from = [
 datetime = "dt"
 dataclasses = "dc"
 "collections.abc" = "cabc"
-"msgspec.json" = "msgspec_json"
+"msgspec.json" = "msjson"
 
 [tool.ruff.lint.pydocstyle]
 # Enforce NumPy docstring style


### PR DESCRIPTION
## Summary
- switch ruff alias to `msjson`
- update imports to use `msjson`

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688142b6079c83229d346819b01eb1bd

## Summary by Sourcery

Rename the msgspec.json alias to msjson and update all references and configuration accordingly

Enhancements:
- Change import alias for msgspec.json from msgspec_json to msjson across source and tests

Build:
- Update ruff alias mapping in pyproject.toml to use msjson instead of msgspec_json