### PR TITLE
Rename fallback handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ See
 - `app.add_websocket_route()` maps WebSocket paths to `WebSocketResource`
   classes, mirroring Falcon's HTTP routing. Initialization parameters can be
   supplied, so one resource class supports multiple configurations.
-- `WebSocketResource` provides `on_connect`, `on_disconnect`, and `on_message`
-  lifecycle hooks.
+- `WebSocketResource` provides `on_connect`, `on_disconnect`, and
+   `on_unhandled`
+   lifecycle hooks.
 - Message payloads are parsed into `msgspec.Struct` classes for speed and type
   safety.
 - Define a `schema` union of tagged `msgspec.Struct` types to enable automatic

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -74,7 +74,7 @@ composable patterns.
 
 - [ ] **Refine Resource API and State Management.**
 
-  - [ ] Rename the fallback handler method from `on_message` to `on_unhandled`
+  - [x] Rename the fallback handler method from `on_message` to `on_unhandled`
     to avoid ambiguity.
 
   - [ ] Implement the `self.state` attribute on `WebSocketResource` as a

--- a/falcon_pachinko/unittests/test_schema_dispatch.py
+++ b/falcon_pachinko/unittests/test_schema_dispatch.py
@@ -44,7 +44,7 @@ class SchemaResource(WebSocketResource):
         """Record leave events."""
         self.events.append(("leave", payload.room))
 
-    async def on_message(self, ws: WebSocketLike, message: str | bytes) -> None:
+    async def on_unhandled(self, ws: WebSocketLike, message: str | bytes) -> None:
         """Record fallback messages."""
         self.events.append(("raw", message))
 

--- a/falcon_pachinko/unittests/test_websocket_resource.py
+++ b/falcon_pachinko/unittests/test_websocket_resource.py
@@ -40,7 +40,7 @@ class EchoResource(WebSocketResource):
         self.seen: list[typing.Any] = []
         self.fallback: list[typing.Any] = []
 
-    async def on_message(self, ws: WebSocketLike, message: str | bytes) -> None:
+    async def on_unhandled(self, ws: WebSocketLike, message: str | bytes) -> None:
         """Handle messages that do not match any registered handler.
 
         Handles messages that do not match any registered handler by appending
@@ -90,7 +90,7 @@ class RawResource(WebSocketResource):
         """
         self.received: list[typing.Any] = []
 
-    async def on_message(self, ws: WebSocketLike, message: str | bytes) -> None:
+    async def on_unhandled(self, ws: WebSocketLike, message: str | bytes) -> None:
         """Handle incoming messages by appending them to the received list.
 
         This method acts as a fallback for messages that do not match any
@@ -170,7 +170,7 @@ class SyncHandlerResource(WebSocketResource):
         """Ignore synchronous handler used for testing."""
         self.seen.append(payload)
 
-    async def on_message(self, ws: WebSocketLike, message: str | bytes) -> None:
+    async def on_unhandled(self, ws: WebSocketLike, message: str | bytes) -> None:
         """Record fallback messages."""
         self.fallback.append(message)
 
@@ -182,7 +182,7 @@ class StrictResource(WebSocketResource):
         self.seen: list[int] = []
         self.fallback: list[str | bytes] = []
 
-    async def on_message(self, ws: WebSocketLike, message: str | bytes) -> None:
+    async def on_unhandled(self, ws: WebSocketLike, message: str | bytes) -> None:
         """Record messages that fail validation."""
         self.fallback.append(message)
 
@@ -199,7 +199,7 @@ class LenientResource(WebSocketResource):
         self.seen: list[int] = []
         self.fallback: list[str | bytes] = []
 
-    async def on_message(self, ws: WebSocketLike, message: str | bytes) -> None:
+    async def on_unhandled(self, ws: WebSocketLike, message: str | bytes) -> None:
         """Record messages that fail validation."""
         self.fallback.append(message)
 


### PR DESCRIPTION
## Summary
- rename fallback `on_message` handler to `on_unhandled`
- update tests and docs for new handler name

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68814a0326c08322a926e032327d5a4f

## Summary by Sourcery

Rename the WebSocketResource fallback handler from on_message to on_unhandled and update all related code, tests, and documentation to use the new method name.

Enhancements:
- Rename the fallback handler method in WebSocketResource from on_message to on_unhandled
- Update internal dispatch logic to call on_unhandled for unhandled messages

Documentation:
- Update README to list on_unhandled as the fallback lifecycle hook
- Mark the handler rename as completed in the roadmap documentation

Tests:
- Modify unit tests to override and verify on_unhandled instead of on_message