### PR TITLE
Implement swappable state for WebSocket resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ See
   classes, mirroring Falcon's HTTP routing. Initialization parameters can be
   supplied, so one resource class supports multiple configurations.
 - `WebSocketResource` provides `on_connect`, `on_disconnect`, and
-   `on_unhandled`
-   lifecycle hooks.
+   `on_unhandled` lifecycle hooks.
 - Message payloads are parsed into `msgspec.Struct` classes for speed and type
   safety.
 - Define a `schema` union of tagged `msgspec.Struct` types to enable automatic

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -312,7 +312,9 @@ logic.
   the resource's self.state attribute will be a swappable, dictionary-like
   proxy. Developers can replace it with a proxy to an external session store
   (e.g., a Redis hash or an in-memory LRU cache) to manage state efficiently at
-  scale.
+  scale. The property lazily creates a plain ``dict`` but can be reassigned to
+  a thread-safe mapping backed by Redis or another store when operating at high
+  concurrency.
 
 ### 3.6. Message Handling and Dispatch
 

--- a/docs/guide-to-modern-python-code-coverage.md
+++ b/docs/guide-to-modern-python-code-coverage.md
@@ -260,44 +260,40 @@ format that Slipcover generates.2
 
 CodeScene provides a dedicated command-line tool, the **CodeScene Coverage CLI
 (**`cs-coverage`**)**, which is the recommended method for uploading coverage
-data.11
+data.
 
 - Installation of cs-coverage:
 
   The tool can be installed using a script provided by CodeScene. In a GitHub
   Actions workflow, you might add a step like:
 
-  ```yaml
-  - name: Install CodeScene Coverage CLI
-    run: curl https://downloads.codescene.io/enterprise/cli/install-cs-coverage-
-    tool.sh | bash -s -- -y ```
-
-```11
+```yaml
+- name: Install CodeScene Coverage CLI
+  run: curl https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
+```
 
 - Command Structure and Options:
 
   The basic command to upload a Cobertura XML file is:
 
-  ````bash cs-coverage upload \ --format "cobertura" \ --metric "line-coverage"
-  \ "path/to/your/coverage.xml" ```
+```bash
+cs-coverage upload \
+  --format "cobertura" \
+  --metric "line-coverage" \
+  "path/to/your/coverage.xml"
+```
 
-  11
-
-  - `--format "cobertura"`: Specifies the input file format.
-
-  - `--metric "line-coverage"`: Specifies the type of coverage metric being
-    uploaded (line coverage is supported for Cobertura by `cs-coverage` 11).
-
-  - `"path/to/your/coverage.xml"`: The path to the Slipcover-generated Cobertura
-    XML file.
-
-  ```
+- `--format "cobertura"`: Specifies the input file format.
+- `--metric "line-coverage"`: Specifies the type of coverage metric being
+  uploaded (line coverage is supported for Cobertura by `cs-coverage`).
+- `"path/to/your/coverage.xml"`: The path to the Slipcover-generated Cobertura
+  XML file.
 
 - Authentication:
 
   The cs-coverage tool uses an environment variable CS_ACCESS_TOKEN for
   authentication. Ensure this variable is set with your CodeScene API token in
-  the environment where the command is run.11 In GitHub Actions:
+  the environment where the command is run. In GitHub Actions:
 
   `yaml env: CS_ACCESS_TOKEN: ${{ secrets.CODESCENE_API_TOKEN }}`
 
@@ -311,8 +307,6 @@ data.11
   these complexities.
 
 ### 4.4. Key Considerations for CodeScene Data
-
-10
 
 - **Commit Association**: CodeScene uses the commit SHA and repository URL to
   link coverage data to the correct version of your codebase. Ensure this
@@ -354,55 +348,43 @@ Here's an example structure for your workflow file (e.g.,
 ```yaml
 name: Python Code Coverage Analysis
 
-on:
-  push:
-    branches: [ main ] # Or your default branch
-  pull_request:
-    branches: [ main ] # Or your default branch
+on: push: branches: [ main ] # Or your default branch pull_request: branches: [
+main ] # Or your default branch
 
-jobs:
-  build-test-analyze:
-    runs-on: ubuntu-latest
-    steps:
+jobs: build-test-analyze: runs-on: ubuntu-latest steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x' # Specify your project's Python version
+        uses: actions/setup-python@v5 with: python-version: '3.x' # Specify
+        your project's Python version
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install slipcover pytest pytest-forked
+        run: | python -m pip install --upgrade pip pip install slipcover pytest
+        pytest-forked
           # Install other project dependencies (e.g., from requirements.txt)
           # pip install -r requirements.txt
 
       - name: Install CodeScene Coverage CLI
-        run: curl https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
+        run: curl
+        https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
+         | bash -s -- -y
 
       - name: Run tests with Slipcover and generate Cobertura report
-        run: |
-          python -m slipcover \
-            --source=./your_project_src  # Adjust to your source directory
-            --omit="*/tests/*,*/venv/*" \
-            --branch \
-            --out coverage.xml \
-            -m pytest --forked -v tests/  # Adjust test path and Pytest args
+        run: | python -m slipcover \
+        --source=./your_project_src  # Adjust to your source directory
+        --omit="*/tests/*,*/venv/*" \
+        --branch \
+        --out coverage.xml \
+        -m pytest --forked -v tests/  # Adjust test path and Pytest args
 
       - name: Upload Coverage Report to CodeScene
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CODESCENE_API_TOKEN }}
-        run: |
-          if [! -f coverage.xml ]; then
-            echo "coverage.xml not found!"
-            exit 1
-          fi
-          cs-coverage upload \
-            --format "cobertura" \
-            --metric "line-coverage" \
-            coverage.xml
+        env: CS_ACCESS_TOKEN: ${{ secrets.CODESCENE_API_TOKEN }} run: | if [!
+        -f coverage.xml ]; then echo "coverage.xml not found!" exit 1 fi
+        cs-coverage upload \
+        --format "cobertura" \
+        --metric "line-coverage" \
+        coverage.xml
 ```
 
 **Important Notes for the Workflow:**
@@ -421,15 +403,12 @@ one option that can parse Cobertura XML files.13
 
 ```yaml
       - name: Post Coverage Summary Comment
-        if: github.event_name == 'pull_request'
-        uses: irongut/CodeCoverageSummary@v1.3.0
-        with:
-          filename: coverage.xml # Action uses the uncompressed XML
-          badge: true
-          fail_below_min: false # Or true, with appropriate thresholds
-          format: 'markdown'
-          output: 'both' # To console and as PR comment
-          thresholds: '60 80' # Example: red <60%, yellow <80%, green >=80%
+        if: github.event_name == 'pull_request' uses:
+        irongut/CodeCoverageSummary@v1.3.0 with: filename: coverage.xml #
+        Action uses the uncompressed XML badge: true fail_below_min: false # Or
+        true, with appropriate thresholds format: 'markdown' output: 'both' #
+        To console and as PR comment thresholds: '60 80' # Example: red <60%,
+        yellow <80%, green >=80%
 ```
 
 This provides a quick glance at coverage changes directly in the PR,

--- a/docs/guide-to-modern-python-code-coverage.md
+++ b/docs/guide-to-modern-python-code-coverage.md
@@ -186,7 +186,7 @@ ensure that:
    Slipcover will automatically handle the collection and aggregation of
    coverage data from the forked processes.
 
-   ````
+   ```
 
 ### 3.3. Understanding `pytest-xdist` for Parallelism
 
@@ -267,14 +267,12 @@ data.11
   The tool can be installed using a script provided by CodeScene. In a GitHub
   Actions workflow, you might add a step like:
 
-  ````yaml
+  ```yaml
   - name: Install CodeScene Coverage CLI
     run: curl https://downloads.codescene.io/enterprise/cli/install-cs-coverage-
     tool.sh | bash -s -- -y ```
 
-  11
-
-  ````
+```11
 
 - Command Structure and Options:
 
@@ -293,7 +291,7 @@ data.11
   - `"path/to/your/coverage.xml"`: The path to the Slipcover-generated Cobertura
     XML file.
 
-  ````
+  ```
 
 - Authentication:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,7 +77,7 @@ composable patterns.
   - [x] Rename the fallback handler method from `on_message` to `on_unhandled`
     to avoid ambiguity.
 
-  - [ ] Implement the `self.state` attribute on `WebSocketResource` as a
+  - [x] Implement the `self.state` attribute on `WebSocketResource` as a
     swappable, dict-like proxy to facilitate external session stores. Provide
     guidance on this pattern for high-concurrency scenarios.
 

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -401,6 +401,27 @@ class WebSocketResource:
     _struct_handlers: typing.ClassVar[dict[type, HandlerInfo]] = {}
     schema: type | None = None
 
+    _state: cabc.MutableMapping[str, typing.Any]
+
+    @property
+    def state(self) -> cabc.MutableMapping[str, typing.Any]:
+        """Per-connection state mapping.
+
+        The default implementation lazily creates an in-memory ``dict`` so
+        subclasses aren't required to call ``super().__init__``. Assign any
+        ``MutableMapping`` to swap in an external session store.
+        """
+        if "_state" not in self.__dict__:
+            self.__dict__["_state"] = {}
+
+        return typing.cast(
+            "cabc.MutableMapping[str, typing.Any]", self.__dict__["_state"]
+        )
+
+    @state.setter
+    def state(self, mapping: cabc.MutableMapping[str, typing.Any]) -> None:
+        self.__dict__["_state"] = mapping
+
     def __init_subclass__(cls, **kwargs: object) -> None:
         """Initialize and merge handler mappings for subclasses."""
         super().__init_subclass__(**kwargs)

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -401,26 +401,24 @@ class WebSocketResource:
     _struct_handlers: typing.ClassVar[dict[type, HandlerInfo]] = {}
     schema: type | None = None
 
-    _state: cabc.MutableMapping[str, typing.Any]
-
     @property
     def state(self) -> cabc.MutableMapping[str, typing.Any]:
         """Per-connection state mapping.
 
         The default implementation lazily creates an in-memory ``dict`` so
         subclasses aren't required to call ``super().__init__``. Assign any
-        ``MutableMapping`` to swap in an external session store.
+        ``MutableMapping`` to swap in an external session store. The default
+        ``dict`` is not thread-safe; replace it with a concurrent mapping when
+        sharing resources across threads.
         """
-        if "_state" not in self.__dict__:
-            self.__dict__["_state"] = {}
+        if not hasattr(self, "_state"):
+            self._state = {}
 
-        return typing.cast(
-            "cabc.MutableMapping[str, typing.Any]", self.__dict__["_state"]
-        )
+        return self._state
 
     @state.setter
     def state(self, mapping: cabc.MutableMapping[str, typing.Any]) -> None:
-        self.__dict__["_state"] = mapping
+        self._state = mapping
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         """Initialize and merge handler mappings for subclasses."""

--- a/falcon_pachinko/unittests/test_websocket_resource.py
+++ b/falcon_pachinko/unittests/test_websocket_resource.py
@@ -353,3 +353,12 @@ async def test_state_custom_mapping_supported() -> None:
     r.state = custom
     r.state["count"] += 1
     assert custom["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_state_is_unique_per_instance() -> None:
+    """Resource instances do not share state by default."""
+    r1 = EchoResource()
+    r2 = EchoResource()
+    r1.state["foo"] = "bar"
+    assert "foo" not in r2.state

--- a/falcon_pachinko/unittests/test_websocket_resource.py
+++ b/falcon_pachinko/unittests/test_websocket_resource.py
@@ -333,3 +333,23 @@ async def test_sync_handler_ignored_and_fallback_behavior() -> None:
     # The sync handler should not be called
     assert r.seen == []
     assert r.fallback == [raw]
+
+
+@pytest.mark.asyncio
+async def test_state_defaults_to_empty_dict() -> None:
+    """Each resource instance starts with an empty state mapping."""
+    r = EchoResource()
+    assert isinstance(r.state, dict)
+    assert not r.state
+    r.state["foo"] = "bar"
+    assert r.state["foo"] == "bar"
+
+
+@pytest.mark.asyncio
+async def test_state_custom_mapping_supported() -> None:
+    """The state attribute can be swapped for any mutable mapping."""
+    r = EchoResource()
+    custom: dict[str, int] = {"count": 1}
+    r.state = custom
+    r.state["count"] += 1
+    assert custom["count"] == 2


### PR DESCRIPTION
## Summary
- implement a lazily created `state` property on `WebSocketResource`
- document how to swap the state mapping for high concurrency
- mark roadmap item complete
- test default and custom state mappings

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6881536762f48322b196c54a633cc251

## Summary by Sourcery

Introduce a pluggable `state` mapping on WebSocket resources to enable in-memory or external session storage, complete related roadmap tasks, and update documentation and tests accordingly.

New Features:
- Add a lazily initialized, swappable `state` property on `WebSocketResource` for per-connection storage

Enhancements:
- Mark the roadmap item for swappable state as completed
- Fix minor formatting in the README and guide docs

Documentation:
- Document the `state` property behavior and how to swap in external session stores
- Correct code block formatting in coverage and design guides

Tests:
- Add unit tests for default `state` mapping and custom mapping assignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a per-connection state property for WebSocket resources, allowing easy and customizable storage of connection-specific data.

* **Documentation**
  * Clarified usage and customization of the new state property in relevant documentation.
  * Improved formatting in various documentation files for better readability.
  * Updated roadmap to reflect completion of the state property feature.

* **Tests**
  * Added tests to verify default behavior and custom assignment of the state property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->