### PR TITLE
Add type check for WebSocketResource.state

### DIFF
--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -418,6 +418,9 @@ class WebSocketResource:
 
     @state.setter
     def state(self, mapping: cabc.MutableMapping[str, typing.Any]) -> None:
+        if not isinstance(mapping, cabc.MutableMapping):
+            msg = f"state must be a MutableMapping, got {type(mapping).__name__}"
+            raise TypeError(msg)
         self._state = mapping
 
     def __init_subclass__(cls, **kwargs: object) -> None:

--- a/falcon_pachinko/unittests/test_websocket_resource.py
+++ b/falcon_pachinko/unittests/test_websocket_resource.py
@@ -362,3 +362,11 @@ async def test_state_is_unique_per_instance() -> None:
     r2 = EchoResource()
     r1.state["foo"] = "bar"
     assert "foo" not in r2.state
+
+
+@pytest.mark.asyncio
+async def test_state_rejects_non_mapping() -> None:
+    """Assigning non-mapping to ``state`` raises ``TypeError``."""
+    r = EchoResource()
+    with pytest.raises(TypeError):
+        r.state = 123  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- validate MutableMapping in `WebSocketResource.state`
- test error is raised when assigning non-mapping

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6883bff6bfec83228494f7e89c1f1e42