### PR TITLE
Refine handler validation and improve routing docs

### DIFF
--- a/falcon_pachinko/behaviour/features/nested_resource.feature
+++ b/falcon_pachinko/behaviour/features/nested_resource.feature
@@ -14,3 +14,8 @@ Feature: Nested resource composition
     Given a router with a nested child resource
     When a client connects to "/parents/42/child/99/grandchild"
     Then the grandchild resource should capture params {"pid": "42", "cid": "99"}
+
+  Scenario: Parameter shadowing overrides parent value
+    Given a router with parameter shadowing resources
+    When a client connects to "/shadow/1/2"
+    Then the shadow child resource should capture params {"pid": "2"}

--- a/falcon_pachinko/exceptions.py
+++ b/falcon_pachinko/exceptions.py
@@ -22,3 +22,9 @@ class SignatureInspectionError(RuntimeError):
 
     def __init__(self, func_qualname: str) -> None:
         super().__init__(f"Cannot inspect signature for handler {func_qualname}")
+
+
+class DuplicateHandlerRegistrationError(Exception):
+    """Raised when attempting to register a duplicate message handler."""
+
+    pass

--- a/falcon_pachinko/exceptions.py
+++ b/falcon_pachinko/exceptions.py
@@ -24,7 +24,7 @@ class SignatureInspectionError(RuntimeError):
         super().__init__(f"Cannot inspect signature for handler {func_qualname}")
 
 
-class DuplicateHandlerRegistrationError(Exception):
-    """Raised when attempting to register a duplicate message handler."""
+class DuplicateHandlerRegistrationError(RuntimeError):
+    """Raised when a message handler is registered more than once."""
 
     pass

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -215,7 +215,24 @@ class WebSocketRouter:
     async def _try_route(
         self, route: _CompiledRoute, req: falcon.Request, ws: WebSocketLike
     ) -> bool:
-        """Attempt to handle ``req`` using ``route``."""
+        """Attempt to handle ``req`` using ``route``.
+
+        The routing sequence is as follows:
+
+        1. :meth:`_validate_and_normalize_path` ensures ``req.path`` matches the
+           route's prefix and returns any captured parameters plus the remaining
+           path.
+        2. A base resource instance is created from the route's factory.
+        3. :meth:`_resolve_resource_and_path` walks any nested subroutes on the
+           base resource using the remaining path, merging parameters at each
+           level.
+        4. If a final resource and empty path are resolved, control is passed to
+           :meth:`_handle_websocket_connection` which accepts or closes the
+           connection via the resource's ``on_connect`` method.
+
+        The method returns ``True`` if the request was handled by this route,
+        ``False`` otherwise.
+        """
         result = self._validate_and_normalize_path(route, req)
         if result is None:
             return False


### PR DESCRIPTION
## Summary
- raise `DuplicateHandlerRegistrationError` when adding a duplicate handler
- validate ambiguous payload parameter definitions
- document WebSocketRouter nested routing sequence
- test parameter shadowing in nested resources
- test ambiguous payload parameter error handling

## Testing
- `make lint`
- `make typecheck`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688a8ca4b6d08322b7357882a68c2f2a

## Summary by Sourcery

Refine WebSocket handler validation by detecting ambiguous payload parameters and introducing DuplicateHandlerRegistrationError for duplicate handlers; enhance WebSocketRouter documentation with a detailed nested routing sequence; and add comprehensive tests for ambiguous payload errors and parameter shadowing

Enhancements:
- Validate ambiguous payload parameters in message handlers and raise HandlerSignatureError
- Introduce DuplicateHandlerRegistrationError for duplicate handler registrations

Documentation:
- Document the nested routing resolution sequence in WebSocketRouter

Tests:
- Add unit tests for ambiguous payload parameter errors
- Add BDD scenario and fixtures for testing parameter shadowing in nested WebSocket routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new exception for duplicate message handler registration errors.
  * Added a new behavioral test scenario for parameter shadowing in nested routes.

* **Bug Fixes**
  * Improved error handling for ambiguous handler method signatures, now raising a specific error when multiple annotated parameters are detected.

* **Documentation**
  * Expanded internal documentation for the routing process to clarify behavior.

* **Tests**
  * Added tests for duplicate handler registration and ambiguous payload parameter detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->