### PR TITLE
Improve return expressions

### DIFF
--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -242,9 +242,7 @@ class WebSocketRouter:
         """Normalize ``remaining`` or return ``None`` if invalid."""
         if not remaining or remaining.startswith("/"):
             return remaining
-        if match.group(0).endswith("/"):
-            return f"/{remaining}"
-        return None
+        return f"/{remaining}" if match.group(0).endswith("/") else None
 
     def _try_subroute_match(
         self, resource: WebSocketResource, path: str
@@ -302,9 +300,7 @@ class WebSocketRouter:
         resolved, remaining, params = self._resolve_subroutes(
             resource, remaining, params
         )
-        if remaining not in ("", "/"):
-            return None
-        return resolved, remaining, params
+        return None if remaining not in ("", "/") else (resolved, remaining, params)
 
     async def _handle_websocket_connection(
         self,

--- a/falcon_pachinko/schema.py
+++ b/falcon_pachinko/schema.py
@@ -64,6 +64,5 @@ def validate_strict_payload(
         allowed = {
             f.name for f in typing.cast("msgspec_inspect.StructType", info).fields
         }
-        extra = set(typing.cast("dict[str, typing.Any]", payload)) - allowed
-        if extra:
+        if extra := set(typing.cast("dict[str, typing.Any]", payload)) - allowed:
             raise_unknown_fields(extra)

--- a/falcon_pachinko/utils.py
+++ b/falcon_pachinko/utils.py
@@ -28,7 +28,7 @@ def raise_unknown_fields(
     if include_payload and payload is not None:
         snippet = str(payload)
         if len(snippet) > 200:
-            snippet = snippet[:197] + "..."
+            snippet = f"{snippet[:197]}..."
         details += f" -> {snippet}"
     raise msgspec.ValidationError(details)
 


### PR DESCRIPTION
## Summary
- simplify router path normalization
- streamline final route resolution
- tidy validation helper
- format unknown field snippet with f-string

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688a8dee3bd88322beae7664a609a86e

## Summary by Sourcery

Improve return expressions by consolidating multi-line conditionals into single-line expressions in routing and validation logic, and enhance snippet formatting with f-strings.

Enhancements:
- Simplify router path normalization with inline conditional return
- Streamline final route resolution with a concise conditional expression
- Refactor schema validation to use an assignment expression for detecting extra fields
- Update unknown field snippet formatting to use f-strings for truncation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified and condensed certain conditional statements for improved code brevity without altering existing functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->