### PR TITLE
Document context passing for nested WebSocket resources

### DIFF
--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -1073,6 +1073,16 @@ globals.
    arguments for the next child. The default implementation returns `{}`, so
    resources opt in to sharing.
 
+   ```python
+   def get_child_context(self) -> dict[str, object]:
+       """Return kwargs to be forwarded to the immediate child resource."""
+       return {}
+   ```
+
+   A concrete signature signals that callers can rely on a plain dict and
+   keeps the hook symmetric with Falcon's HTTP-style `get_child_scope()`
+   patterns.
+
 2. **Shared state object**
 
    Pass the same connection-scoped `state` proxy down the chain. The router
@@ -1083,9 +1093,10 @@ globals.
 
    For each path segment the router will:
 
-   - Instantiate the parent with path parameters and any static init args.
+   - Instantiate the parent with path parameters and static init args.
    - Invoke `get_child_context()` to obtain context for the child.
-   - Instantiate the child, merging path params with the context kwargs.
+   - Instantiate the child, merging path params with the context
+     kwargs.
    - Propagate the shared `state` proxy.
 
 4. **Convenience API**

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -1111,6 +1111,38 @@ globals.
    `TasksResource`, verifying that the child receives the object and both
    modify the shared `state`.
 
+   The relationships and runtime behavior are illustrated below.
+
+   ```mermaid
+   classDiagram
+       class WebSocketResource {
+           +get_child_context() kwargs
+           state
+       }
+       class WebSocketRouter {
+           +instantiate_resource_chain(path_segments, path_params, static_args)
+           +add_subroute(child_factory, *args, **kwargs)
+       }
+       WebSocketResource <|-- ParentResource
+       WebSocketResource <|-- ChildResource
+       WebSocketRouter o-- WebSocketResource : instantiates
+       ParentResource o-- ChildResource : add_subroute
+       ParentResource --> ChildResource : get_child_context()
+       ParentResource --> ChildResource : state (shared)
+   ```
+
+   ```mermaid
+   sequenceDiagram
+       participant Router as WebSocketRouter
+       participant Parent as ParentResource
+       participant Child as ChildResource
+       Router->>Parent: Instantiate with path params, static args
+       Router->>Parent: get_child_context()
+       Parent-->>Router: context kwargs
+       Router->>Child: Instantiate with path params + context kwargs
+       Router->>Child: Set child.state = parent.state (unless overridden)
+   ```
+
 ### 5.3. High-Performance Schema-Driven Dispatch with `msgspec`
 
 This proposal elevates the dispatch mechanism using `msgspec` and its support

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -90,7 +90,9 @@ composable patterns.
     nested paths.
 
   - [ ] Design and implement a robust context-passing mechanism for parent
-    resources to inject state into child resources.
+    resources to inject state into child resources (see
+    [§5.2.3](falcon-websocket-extension-design.md#523-context-passing-for-
+    nested-resources)).
 
     - [ ] Add an overridable `get_child_context()` hook on
       `WebSocketResource` so parents can explicitly share data with the next

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,23 +95,25 @@ composable patterns.
     nested-resources)).
 
     - [ ] Add an overridable `get_child_context()` hook on
-      `WebSocketResource` so parents can explicitly share data with the next
+      `WebSocketResource`¹ so parents can explicitly share data with the next
       child in the chain.
 
     - [ ] Propagate a shared, connection-scoped `state` proxy unless a parent
-      provides an alternative via `get_child_context()`.
+      provides an alternative via `get_child_context()`¹.
 
     - [ ] Update `WebSocketRouter` to instantiate resources sequentially,
       merging path params with parent-supplied context and passing along the
-      shared `state`.
+      shared `state`¹.
 
     - [ ] Enhance `add_subroute()` to record child factories and static
       arguments while retaining a reference to the parent for router
-      composition.
+      composition¹.
 
     - [ ] Provide documentation and tests, such as injecting a `project`
       object into `TasksResource` and verifying modifications to shared
-      `state`.
+      `state`¹.
+
+[¹](falcon-websocket-extension-design.md#523-context-passing-for-nested-resources)
 
 ## Phase 3: Lifespan Workers and Connection Management
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -92,6 +92,25 @@ composable patterns.
   - [ ] Design and implement a robust context-passing mechanism for parent
     resources to inject state into child resources.
 
+    - [ ] Add an overridable `get_child_context()` hook on
+      `WebSocketResource` so parents can explicitly share data with the next
+      child in the chain.
+
+    - [ ] Propagate a shared, connection-scoped `state` proxy unless a parent
+      provides an alternative via `get_child_context()`.
+
+    - [ ] Update `WebSocketRouter` to instantiate resources sequentially,
+      merging path params with parent-supplied context and passing along the
+      shared `state`.
+
+    - [ ] Enhance `add_subroute()` to record child factories and static
+      arguments while retaining a reference to the parent for router
+      composition.
+
+    - [ ] Provide documentation and tests, such as injecting a `project`
+      object into `TasksResource` and verifying modifications to shared
+      `state`.
+
 ## Phase 3: Lifespan Workers and Connection Management
 
 This phase implements the redesigned, ASGI-native background worker system and


### PR DESCRIPTION
## Summary
- outline roadmap tasks for context handoff between parent and child websocket resources
- expand design docs with per-resource context hooks, shared state propagation, and router instantiation details

## Testing
- `make markdownlint`
- `make nixie` *(fails: error: too many arguments. Expected 0 arguments but got 1.)*

------
https://chatgpt.com/codex/tasks/task_e_68906cf84be88322a0b2ffd6a8067061

## Summary by Sourcery

Document the design and planning for context passing in nested WebSocket resources by adding a detailed design section and updating the roadmap with implementation tasks

Documentation:
- Add a design doc section describing per-resource context hooks, shared state propagation, router instantiation, and convenience API for nested WebSocket resources
- Update the project roadmap with detailed tasks for implementing the context-passing mechanism between parent and child WebSocket resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed explanation of context and state sharing for nested WebSocket resources, including explicit context handoff and shared state propagation.
  * Expanded the project roadmap with specific tasks for implementing and documenting parent-to-child context passing in nested resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->