### PR TITLE
Add child context hook for WebSocketResource

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -89,27 +89,27 @@ composable patterns.
   - [x] Enhance the `WebSocketRouter`'s matching logic to handle multi-level
     nested paths.
 
-  - [ ] Design and implement a robust context-passing mechanism for parent
+  - [x] Design and implement a robust context-passing mechanism for parent
     resources to inject state into child resources (see
-    [§5.2.3](falcon-websocket-extension-design.md#523-context-passing-for-
-    nested-resources)).
+    [§5.2.3](falcon-websocket-extension-design.md#523-context-passing-for- nested-resources)
+     ).
 
-    - [ ] Add an overridable `get_child_context()` hook on
+    - [x] Add an overridable `get_child_context()` hook on
       `WebSocketResource`¹ so parents can explicitly share data with the next
       child in the chain.
 
-    - [ ] Propagate a shared, connection-scoped `state` proxy unless a parent
+    - [x] Propagate a shared, connection-scoped `state` proxy unless a parent
       provides an alternative via `get_child_context()`¹.
 
-    - [ ] Update `WebSocketRouter` to instantiate resources sequentially,
+    - [x] Update `WebSocketRouter` to instantiate resources sequentially,
       merging path params with parent-supplied context and passing along the
       shared `state`¹.
 
-    - [ ] Enhance `add_subroute()` to record child factories and static
+    - [x] Enhance `add_subroute()` to record child factories and static
       arguments while retaining a reference to the parent for router
       composition¹.
 
-    - [ ] Provide documentation and tests, such as injecting a `project`
+    - [x] Provide documentation and tests, such as injecting a `project`
       object into `TasksResource` and verifying modifications to shared
       `state`¹.
 

--- a/falcon_pachinko/behaviour/features/nested_resource.feature
+++ b/falcon_pachinko/behaviour/features/nested_resource.feature
@@ -19,3 +19,9 @@ Feature: Nested resource composition
     Given a router with parameter shadowing resources
     When a client connects to "/shadow/1/2"
     Then the shadow child resource should capture params {"pid": "2"}
+
+  Scenario: Parent passes context to child resource
+    Given a router with context-passing resources
+    When a client connects to "/ctx/child"
+    Then the context child resource should receive project "acme"
+    And the shared state should contain flags from both resources

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -77,6 +77,17 @@ class WebSocketResource:
         subroutes.append((pattern, factory))
         self._subroutes = subroutes
 
+    def get_child_context(self) -> dict[str, object]:
+        """Return kwargs to be forwarded to the next child resource.
+
+        Override this hook to explicitly share context or dependencies with a
+        nested resource. The returned mapping is applied to the child's
+        constructor. If ``state`` is included, its value will replace the
+        connection-scoped ``state`` passed to the child; otherwise, the parent
+        state is propagated automatically.
+        """
+        return {}
+
     @property
     def state(self) -> cabc.MutableMapping[str, typing.Any]:
         """Per-connection state mapping."""

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -272,7 +272,10 @@ class WebSocketRouter:
                     remaining := self._normalize_path_remaining(remaining, match)
                 ) is None:
                     return None
-                new_resource = factory()
+                context = resource.get_child_context()
+                child_kwargs = {k: v for k, v in context.items() if k != "state"}
+                new_resource = factory(**child_kwargs)
+                new_resource.state = context.get("state", resource.state)
                 params = match.groupdict()
                 return new_resource, remaining, params
         return None


### PR DESCRIPTION
## Summary
- support parent-to-child context via new `get_child_context()` hook
- propagate state through nested WebSocketResource chain
- document completion of context-passing roadmap item

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make markdownlint`
- `make nixie` *(fails: error: too many arguments. Expected 0 arguments but got 1.)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893d7c835a48322bebe9335119702e0

## Summary by Sourcery

Implement a robust context-passing mechanism for nested WebSocketResource chains by introducing a get_child_context hook, updating router logic to merge context and state, and adding corresponding documentation and tests.

New Features:
- Add get_child_context hook on WebSocketResource to enable parents to supply constructor arguments to child resources
- Allow nested resources to propagate or override a shared connection-scoped state between parent and child

Enhancements:
- Update WebSocketRouter to invoke get_child_context and merge constructor kwargs and shared state when instantiating subroutes

Documentation:
- Mark completion of context-passing roadmap item in documentation

Tests:
- Add BDD feature scenarios and unit tests to verify context injection and shared state propagation across nested WebSocket resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for parent WebSocket resources to pass context and shared state to nested child resources.
  * Added an overridable method for customizing context passed to child resources.

* **Tests**
  * Added behavioral and unit tests to verify context injection and shared state propagation between parent and child WebSocket resources.

* **Documentation**
  * Updated roadmap to reflect completion of tasks related to context-passing for nested WebSocket resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->