### PR TITLE
Adopt lifespan workers

### DIFF
--- a/docs/roadmap-v1-legacy.md
+++ b/docs/roadmap-v1-legacy.md
@@ -29,9 +29,9 @@ after formatting.
 
 4. **Background Worker Integration** (lines 342-375)
 
-   - [ ] Expose `app.add_websocket_worker` to register asynchronous workers that
+   - [ ] Provide a `WorkerController` for registering asynchronous workers that
      use `app.ws_connection_manager`.
-   - [ ] Ensure workers can be started with the application’s lifespan events.
+   - [ ] Ensure workers are managed with the application’s lifespan events.
 
 5. **Testing Utilities**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -129,7 +129,7 @@ finalizes the connection manager API.
 
   - [x] Implement the optional `@worker` decorator for clarity.
 
-  - [ ] Update all examples and documentation to use the `@app.lifespan` pattern
+  - [x] Update all examples and documentation to use the `@app.lifespan` pattern
     for managing workers, completely removing the old `add_websocket_worker`
     concept.
 

--- a/examples/random_status/server.py
+++ b/examples/random_status/server.py
@@ -1,9 +1,6 @@
-"""Example server showcasing the ``falcon_pachinko`` extension.
+"""Random status example using lifespan-managed workers.
 
-The application exposes an HTTP endpoint and a WebSocket route that
-processes ``status`` messages and periodically broadcasts random
-numbers. Run the server with ``uvicorn`` and connect using the
-accompanying ``client.py`` script.
+Run the accompanying ``client.py`` script to interact with the server.
 """
 # /// script
 # dependencies = [
@@ -18,14 +15,25 @@ accompanying ``client.py`` script.
 from __future__ import annotations
 
 import asyncio
+import contextlib as cl
 import secrets
-import typing
+import typing as t
 
 import aiosqlite
 import falcon.asgi
 
-# WebSocket disconnection will be handled by generic exceptions
-from falcon_pachinko import WebSocketLike, WebSocketResource, handles_message, install
+from falcon_pachinko import (
+    WebSocketLike,
+    WebSocketResource,
+    WorkerController,
+    handles_message,
+    install,
+    worker,
+)
+
+if t.TYPE_CHECKING:
+    import collections.abc as cabc
+    import contextlib as cl_typing
 
 
 async def _setup_db() -> aiosqlite.Connection:
@@ -39,70 +47,51 @@ async def _setup_db() -> aiosqlite.Connection:
 DB = asyncio.run(_setup_db())
 
 
-class StatusPayload(typing.TypedDict):
+class StatusPayload(t.TypedDict):
     """Type definition for status message payload."""
 
     text: str
 
 
-async def random_worker(ws: WebSocketLike) -> None:
-    """
-    Periodically sends random numbers to the client over a WebSocket connection.
-
-    Runs indefinitely, sending a JSON message with a random number every 5 seconds
-    until cancelled.
-    """
+@worker
+async def random_worker(conn_mgr) -> None:  # noqa: ANN001
+    """Periodically broadcast random numbers to all connections."""
     try:
         while True:
             await asyncio.sleep(5)
             number = secrets.randbelow(65536)
-            await ws.send_media({"type": "random", "payload": str(number)})
-    except (ConnectionError, OSError):
-        # Exit if the connection is lost
-        pass
+            for ws in list(conn_mgr.connections.values()):
+                with cl.suppress(ConnectionError, OSError):
+                    await ws.send_media({"type": "random", "payload": str(number)})
     except asyncio.CancelledError:
         pass
 
 
 class StatusResource(WebSocketResource):
-    """WebSocket resource for handling status updates and random number broadcasting."""
+    """WebSocket resource for handling status updates."""
 
-    def __init__(self) -> None:
-        """Initialize the StatusResource with no active background task."""
-        self._task: asyncio.Task[None] | None = None
+    def __init__(self, conn_mgr) -> None:  # noqa: ANN001
+        self._conn_mgr = conn_mgr
+        self._conn_id: str | None = None
 
     async def on_connect(
         self, req: falcon.Request, ws: WebSocketLike, **_: object
     ) -> bool:
-        """Handle a new WebSocket connection by accepting it and starting a background
-        task.
-
-        Accepts the connection and starts a background task to send random numbers.
-
-        Returns
-        -------
-            True to indicate the WebSocket connection has been accepted.
-        """
+        """Accept the connection and register it with the manager."""
         await ws.accept()
-        self._task = asyncio.create_task(random_worker(ws))
+        conn_id = secrets.token_hex(16)
+        self._conn_mgr.connections[conn_id] = ws
+        self._conn_id = conn_id
         return True
 
     async def on_disconnect(self, ws: WebSocketLike, close_code: int) -> None:
-        """Handle cleanup when a WebSocket connection is closed.
-
-        Cancels the background task if it exists when the connection is closed.
-        """
-        if self._task:
-            self._task.cancel()
+        """Unregister the connection on disconnect."""
+        if self._conn_id:
+            self._conn_mgr.connections.pop(self._conn_id, None)
 
     @handles_message("status")
     async def update_status(self, ws: WebSocketLike, payload: StatusPayload) -> None:
-        """
-        Handle incoming WebSocket "status" messages to update the stored status value.
-
-        Updates the status in the database with the provided text and sends an
-        acknowledgment message back to the client containing the updated value.
-        """
+        """Update the stored status value and acknowledge."""
         text = payload["text"]
         await DB.execute("UPDATE status SET value=?", (text,))
         await DB.commit()
@@ -113,28 +102,55 @@ class StatusEndpoint:
     """HTTP endpoint for retrieving the current status value."""
 
     async def on_get(self, req: falcon.Request, resp: falcon.Response) -> None:
-        """
-        Handle HTTP GET requests to retrieve the current status value.
-
-        Responds with a JSON object containing the current status text from the
-        database under the "status" key. If no status is set, the value is null.
-        """
+        """Return the current status value as JSON."""
         async with DB.execute("SELECT value FROM status") as cursor:
             row = await cursor.fetchone()
         resp.media = {"status": row[0] if row else None}
 
 
-def create_app() -> falcon.asgi.App:
-    """
-    Create and configure the Falcon ASGI application with WebSocket and HTTP routes.
+class LifespanApp(falcon.asgi.App):
+    """Falcon ASGI App with a minimal lifespan decorator."""
 
-    Returns
-    -------
-        The configured Falcon ASGI application instance.
-    """
-    app = falcon.asgi.App()
+    def __init__(self) -> None:
+        super().__init__()
+        self._lifespan_handler: (
+            cabc.Callable[
+                [falcon.asgi.App], cl_typing.AbstractAsyncContextManager[None]
+            ]
+            | None
+        ) = None
+
+    def lifespan(
+        self, fn: cabc.Callable[[falcon.asgi.App], cabc.AsyncIterator[None]]
+    ) -> cabc.Callable[[falcon.asgi.App], cl_typing.AbstractAsyncContextManager[None]]:  # type: ignore[override]
+        """Register a lifespan context manager."""
+        manager = cl.asynccontextmanager(fn)
+        self._lifespan_handler = manager
+        return manager
+
+    def lifespan_context(self) -> cl_typing.AbstractAsyncContextManager[None]:
+        """Return the registered lifespan context manager."""
+        if self._lifespan_handler is None:
+            msg = "lifespan handler not set"
+            raise RuntimeError(msg)
+        return self._lifespan_handler(self)
+
+
+def create_app() -> falcon.asgi.App:
+    """Create and configure the Falcon ASGI application."""
+    app = LifespanApp()
     install(app)
-    app.add_websocket_route("/ws", StatusResource)  # type: ignore[attr-defined]
+    conn_mgr = app.ws_connection_manager  # type: ignore[attr-defined]
+
+    controller = WorkerController()
+
+    @app.lifespan
+    async def lifespan(app_instance) -> t.AsyncIterator[None]:  # noqa: ANN001
+        await controller.start(random_worker, conn_mgr=conn_mgr)
+        yield
+        await controller.stop()
+
+    app.add_websocket_route("/ws", lambda: StatusResource(conn_mgr))  # type: ignore[attr-defined]
     app.add_route("/status", StatusEndpoint())
     return app
 

--- a/tests/behaviour/lifespan_workers.feature
+++ b/tests/behaviour/lifespan_workers.feature
@@ -1,0 +1,6 @@
+Feature: Lifespan-based worker management
+
+  Scenario: worker runs during lifespan
+    Given an app with a lifespan-managed worker
+    When the app lifespan is executed
+    Then the worker has run

--- a/tests/behaviour/test_lifespan_workers_steps.py
+++ b/tests/behaviour/test_lifespan_workers_steps.py
@@ -1,0 +1,86 @@
+"""Behavioural tests for lifespan-managed workers."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib as cl
+import typing as t
+
+import falcon.asgi
+from pytest_bdd import given, scenario, then, when
+
+from falcon_pachinko.workers import WorkerController, worker
+
+if t.TYPE_CHECKING:
+    import collections.abc as cabc
+    import contextlib as cl_typing
+
+
+class LifespanApp(falcon.asgi.App):
+    """Falcon ASGI App with a minimal lifespan decorator."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._lifespan_handler: (
+            t.Callable[[falcon.asgi.App], cl_typing.AbstractAsyncContextManager[None]]
+            | None
+        ) = None
+
+    def lifespan(
+        self, fn: t.Callable[[falcon.asgi.App], cabc.AsyncIterator[None]]
+    ) -> t.Callable[[falcon.asgi.App], cl_typing.AbstractAsyncContextManager[None]]:  # type: ignore[override]
+        """Register a lifespan context manager."""
+        manager = cl.asynccontextmanager(fn)
+        self._lifespan_handler = manager
+        return manager
+
+    def lifespan_context(self) -> cl_typing.AbstractAsyncContextManager[None]:
+        """Return the registered lifespan context manager."""
+        if self._lifespan_handler is None:
+            msg = "lifespan handler not set"
+            raise RuntimeError(msg)
+        return self._lifespan_handler(self)
+
+
+@scenario("lifespan_workers.feature", "worker runs during lifespan")
+def test_lifespan_worker() -> None:  # pragma: no cover - bdd registration
+    """Scenario: worker runs during lifespan."""
+
+
+@given("an app with a lifespan-managed worker", target_fixture="app_with_worker")
+def create_app_with_worker() -> tuple[LifespanApp, dict[str, bool]]:
+    """Create an app that starts a worker during lifespan."""
+    app = LifespanApp()
+    controller = WorkerController()
+    state: dict[str, bool] = {"ran": False}
+
+    @worker
+    async def run_once(*, state: dict[str, bool]) -> None:
+        state["ran"] = True
+
+    @app.lifespan
+    async def lifespan(app_instance) -> cabc.AsyncIterator[None]:  # noqa: ANN001
+        await controller.start(run_once, state=state)
+        yield
+        await controller.stop()
+
+    return app, state
+
+
+@when("the app lifespan is executed")
+def run_lifespan(app_with_worker: tuple[LifespanApp, dict[str, bool]]) -> None:
+    """Run the application's lifespan context."""
+    app, _ = app_with_worker
+
+    async def _runner() -> None:
+        async with app.lifespan_context():
+            await asyncio.sleep(0)
+
+    asyncio.run(_runner())
+
+
+@then("the worker has run")
+def worker_has_run(app_with_worker: tuple[LifespanApp, dict[str, bool]]) -> None:
+    """Assert that the worker executed."""
+    _, state = app_with_worker
+    assert state["ran"] is True

--- a/tests/test_worker_controller_unit.py
+++ b/tests/test_worker_controller_unit.py
@@ -1,0 +1,30 @@
+"""Unit tests for the WorkerController utility."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from falcon_pachinko.workers import WorkerController, worker
+
+
+@worker
+async def _sample_worker(*, flag: dict[str, bool]) -> None:
+    flag["ran"] = True
+    try:
+        while True:
+            await asyncio.sleep(0)
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_worker_controller_runs_and_stops() -> None:
+    """Start and stop a worker, verifying context injection."""
+    flag: dict[str, bool] = {}
+    controller = WorkerController()
+    await controller.start(_sample_worker, flag=flag)
+    await asyncio.sleep(0)
+    assert flag["ran"] is True
+    await controller.stop()


### PR DESCRIPTION
## Summary
- remove add_websocket_worker guidance
- show lifespan-managed workers in docs and examples
- cover worker controller with unit and behavioural tests

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: Error running command bun x @mermaid-js/mermaid-cli; missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689bc884be78832282d963c250742d17