### PR TITLE
Expand WorkerController unit tests

### DIFF
--- a/tests/test_worker_controller_unit.py
+++ b/tests/test_worker_controller_unit.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import typing
 
 import pytest
+import pytest_asyncio
 
 from falcon_pachinko.workers import WorkerController, worker
+
+if typing.TYPE_CHECKING:  # pragma: no cover - used only for type checking
+    import collections.abc as cabc
 
 
 @worker
@@ -19,12 +24,63 @@ async def _sample_worker(*, flag: dict[str, bool]) -> None:
         pass
 
 
+@worker
+async def _failing_worker() -> None:
+    """Yield once before raising an error."""
+    await asyncio.sleep(0)
+    raise RuntimeError("boom")
+
+
+@pytest_asyncio.fixture
+async def controller() -> cabc.AsyncIterator[WorkerController]:
+    """Yield a controller and always stop it in teardown."""
+    ctrl = WorkerController()
+    try:
+        yield ctrl
+    finally:
+        await ctrl.stop()
+
+
 @pytest.mark.asyncio
-async def test_worker_controller_runs_and_stops() -> None:
+async def test_worker_controller_runs_and_stops(
+    controller: WorkerController,
+) -> None:
     """Start and stop a worker, verifying context injection."""
     flag: dict[str, bool] = {}
-    controller = WorkerController()
     await controller.start(_sample_worker, flag=flag)
     await asyncio.sleep(0)
     assert flag["ran"] is True
     await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_twice_raises_error(controller: WorkerController) -> None:
+    """Starting twice without stopping should raise an error."""
+    flag: dict[str, bool] = {}
+    await controller.start(_sample_worker, flag=flag)
+    with pytest.raises(RuntimeError):
+        await controller.start(_sample_worker, flag=flag)
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_is_idempotent(controller: WorkerController) -> None:
+    """Stopping multiple times should not raise."""
+    flag: dict[str, bool] = {}
+    await controller.start(_sample_worker, flag=flag)
+    await asyncio.sleep(0)
+    await controller.stop()
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_exception_propagates_on_stop(
+    controller: WorkerController,
+) -> None:
+    """Exceptions raised by workers should surface when stopping."""
+    await controller.start(_failing_worker)
+    # Yield twice so the worker runs past its internal sleep and raises
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    with pytest.raises(RuntimeError, match="boom"):
+        await controller.stop()


### PR DESCRIPTION
## Summary
- add fixture-backed WorkerController tests
- verify start double-call, stop idempotency, and error propagation

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e3862d9b48322a711e6415dbf53e9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage for worker controller behavior.
  * Added scenarios verifying double-start errors, idempotent stop, and exception propagation during shutdown.
  * Introduced a failing worker scenario to validate error handling.
  * Standardized setup and teardown with fixtures for consistent lifecycle management.
  * Improved test reliability and isolation, reducing flakiness and increasing confidence in error paths and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->