### PR TITLE
Document WorkerController example and test worker shutdown

### DIFF
--- a/docs/roadmap-v1-legacy.md
+++ b/docs/roadmap-v1-legacy.md
@@ -29,9 +29,10 @@ after formatting.
 
 4. **Background Worker Integration** (lines 342-375)
 
-   - [ ] Provide a `WorkerController` for registering asynchronous workers that
-     use `app.ws_connection_manager`.
-   - [ ] Ensure workers are managed with the application’s lifespan events.
+    - [x] Provide a `WorkerController` for registering asynchronous workers that
+      use `app.ws_connection_manager`.
+    - [x] Ensure workers are managed with the application’s lifespan events.
+      (See README for a concrete example.)
 
 5. **Testing Utilities**
 

--- a/docs/roadmap-v1-legacy.md
+++ b/docs/roadmap-v1-legacy.md
@@ -32,7 +32,7 @@ after formatting.
     - [x] Provide a `WorkerController` for registering asynchronous workers that
       use `app.ws_connection_manager`.
     - [x] Ensure workers are managed with the application’s lifespan events.
-      (See README for a concrete example.)
+      (See examples/random_status/server.py for a concrete example.)
 
 5. **Testing Utilities**
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for falcon-pachinko."""

--- a/tests/behaviour/__init__.py
+++ b/tests/behaviour/__init__.py
@@ -1,0 +1,1 @@
+"""Behavioural test utilities."""

--- a/tests/behaviour/_lifespan.py
+++ b/tests/behaviour/_lifespan.py
@@ -1,0 +1,38 @@
+"""Minimal Falcon ASGI app with a lifespan decorator for tests and examples."""
+
+from __future__ import annotations
+
+import contextlib as cl
+import typing as t
+
+import falcon.asgi
+
+if t.TYPE_CHECKING:  # pragma: no cover - typing helpers
+    import collections.abc as cabc
+    import contextlib as cl_typing
+
+
+class LifespanApp(falcon.asgi.App):
+    """Falcon ASGI App with a minimal lifespan decorator."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._lifespan_handler: (
+            t.Callable[[falcon.asgi.App], cl_typing.AbstractAsyncContextManager[None]]
+            | None
+        ) = None
+
+    def lifespan(
+        self, fn: t.Callable[[LifespanApp], cabc.AsyncIterator[None]]
+    ) -> t.Callable[[LifespanApp], cl_typing.AbstractAsyncContextManager[None]]:  # type: ignore[override]
+        """Register a lifespan context manager."""
+        manager = cl.asynccontextmanager(fn)
+        self._lifespan_handler = manager
+        return manager
+
+    def lifespan_context(self) -> cl_typing.AbstractAsyncContextManager[None]:
+        """Return the registered lifespan context manager."""
+        if self._lifespan_handler is None:
+            msg = "lifespan handler not set"
+            raise RuntimeError(msg)
+        return self._lifespan_handler(self)

--- a/tests/behaviour/_lifespan.py
+++ b/tests/behaviour/_lifespan.py
@@ -18,7 +18,7 @@ class LifespanApp(falcon.asgi.App):
     def __init__(self) -> None:
         super().__init__()
         self._lifespan_handler: (
-            t.Callable[[falcon.asgi.App], cl_typing.AbstractAsyncContextManager[None]]
+            t.Callable[[LifespanApp], cl_typing.AbstractAsyncContextManager[None]]
             | None
         ) = None
 

--- a/tests/behaviour/lifespan_workers.feature
+++ b/tests/behaviour/lifespan_workers.feature
@@ -4,3 +4,4 @@ Feature: Lifespan-based worker management
     Given an app with a lifespan-managed worker
     When the app lifespan is executed
     Then the worker has run
+    And the worker stops after the lifespan ends

--- a/tests/behaviour/test_lifespan_workers_steps.py
+++ b/tests/behaviour/test_lifespan_workers_steps.py
@@ -3,43 +3,15 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib as cl
 import typing as t
 
-import falcon.asgi
 from pytest_bdd import given, scenario, then, when
 
 from falcon_pachinko.workers import WorkerController, worker
+from tests.behaviour._lifespan import LifespanApp
 
 if t.TYPE_CHECKING:
     import collections.abc as cabc
-    import contextlib as cl_typing
-
-
-class LifespanApp(falcon.asgi.App):
-    """Falcon ASGI App with a minimal lifespan decorator."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._lifespan_handler: (
-            t.Callable[[falcon.asgi.App], cl_typing.AbstractAsyncContextManager[None]]
-            | None
-        ) = None
-
-    def lifespan(
-        self, fn: t.Callable[[LifespanApp], cabc.AsyncIterator[None]]
-    ) -> t.Callable[[LifespanApp], cl_typing.AbstractAsyncContextManager[None]]:  # type: ignore[override]
-        """Register a lifespan context manager."""
-        manager = cl.asynccontextmanager(fn)
-        self._lifespan_handler = manager
-        return manager
-
-    def lifespan_context(self) -> cl_typing.AbstractAsyncContextManager[None]:
-        """Return the registered lifespan context manager."""
-        if self._lifespan_handler is None:
-            msg = "lifespan handler not set"
-            raise RuntimeError(msg)
-        return self._lifespan_handler(self)
 
 
 @scenario("lifespan_workers.feature", "worker runs during lifespan")
@@ -48,47 +20,65 @@ def test_lifespan_worker() -> None:  # pragma: no cover - bdd registration
 
 
 @given("an app with a lifespan-managed worker", target_fixture="app_with_worker")
-def create_app_with_worker() -> tuple[LifespanApp, dict[str, bool], asyncio.Event]:
+def create_app_with_worker() -> tuple[
+    LifespanApp, dict[str, bool], asyncio.Event, asyncio.Event
+]:
     """Create an app that starts a worker during lifespan."""
     app = LifespanApp()
     controller = WorkerController()
     state: dict[str, bool] = {"ran": False}
-    done = asyncio.Event()
+    started = asyncio.Event()
+    stopped = asyncio.Event()
 
     @worker
-    async def run_once(*, state: dict[str, bool], done: asyncio.Event) -> None:
+    async def run_until_cancelled(
+        *, state: dict[str, bool], started: asyncio.Event, stopped: asyncio.Event
+    ) -> None:
         state["ran"] = True
-        done.set()
+        started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            stopped.set()
 
     @app.lifespan
-    async def lifespan(
-        app_instance: falcon.asgi.App,
-    ) -> cabc.AsyncIterator[None]:
-        await controller.start(run_once, state=state, done=done)
+    async def lifespan(app_instance: LifespanApp) -> cabc.AsyncIterator[None]:
+        await controller.start(
+            run_until_cancelled, state=state, started=started, stopped=stopped
+        )
         yield
         await controller.stop()
 
-    return app, state, done
+    return app, state, started, stopped
 
 
 @when("the app lifespan is executed")
 def run_lifespan(
-    app_with_worker: tuple[LifespanApp, dict[str, bool], asyncio.Event],
+    app_with_worker: tuple[LifespanApp, dict[str, bool], asyncio.Event, asyncio.Event],
 ) -> None:
     """Run the application's lifespan context."""
-    app, _, done = app_with_worker
+    app, _, started, _ = app_with_worker
 
     async def _runner() -> None:
         async with app.lifespan_context():
-            await done.wait()
+            await asyncio.wait_for(started.wait(), timeout=2.0)
 
     asyncio.run(_runner())
 
 
 @then("the worker has run")
 def worker_has_run(
-    app_with_worker: tuple[LifespanApp, dict[str, bool], asyncio.Event],
+    app_with_worker: tuple[LifespanApp, dict[str, bool], asyncio.Event, asyncio.Event],
 ) -> None:
     """Assert that the worker executed."""
-    _, state, _ = app_with_worker
+    _, state, _, _ = app_with_worker
     assert state["ran"] is True
+
+
+@then("the worker stops after the lifespan ends")
+def worker_stops(
+    app_with_worker: tuple[LifespanApp, dict[str, bool], asyncio.Event, asyncio.Event],
+) -> None:
+    """Assert that the worker stopped after the lifespan context."""
+    _, _, _, stopped = app_with_worker
+    assert stopped.is_set()

--- a/tests/behaviour/test_lifespan_workers_steps.py
+++ b/tests/behaviour/test_lifespan_workers_steps.py
@@ -10,6 +10,9 @@ from pytest_bdd import given, scenario, then, when
 from falcon_pachinko.workers import WorkerController, worker
 from tests.behaviour._lifespan import LifespanApp
 
+START_TIMEOUT = 2.0
+AppWithWorker = tuple[LifespanApp, dict[str, bool], asyncio.Event, asyncio.Event]
+
 if t.TYPE_CHECKING:
     import collections.abc as cabc
 
@@ -20,9 +23,7 @@ def test_lifespan_worker() -> None:  # pragma: no cover - bdd registration
 
 
 @given("an app with a lifespan-managed worker", target_fixture="app_with_worker")
-def create_app_with_worker() -> tuple[
-    LifespanApp, dict[str, bool], asyncio.Event, asyncio.Event
-]:
+def create_app_with_worker() -> AppWithWorker:
     """Create an app that starts a worker during lifespan."""
     app = LifespanApp()
     controller = WorkerController()
@@ -53,32 +54,26 @@ def create_app_with_worker() -> tuple[
 
 
 @when("the app lifespan is executed")
-def run_lifespan(
-    app_with_worker: tuple[LifespanApp, dict[str, bool], asyncio.Event, asyncio.Event],
-) -> None:
+def run_lifespan(app_with_worker: AppWithWorker) -> None:
     """Run the application's lifespan context."""
     app, _, started, _ = app_with_worker
 
     async def _runner() -> None:
         async with app.lifespan_context():
-            await asyncio.wait_for(started.wait(), timeout=2.0)
+            await asyncio.wait_for(started.wait(), timeout=START_TIMEOUT)
 
     asyncio.run(_runner())
 
 
 @then("the worker has run")
-def worker_has_run(
-    app_with_worker: tuple[LifespanApp, dict[str, bool], asyncio.Event, asyncio.Event],
-) -> None:
+def worker_has_run(app_with_worker: AppWithWorker) -> None:
     """Assert that the worker executed."""
     _, state, _, _ = app_with_worker
     assert state["ran"] is True
 
 
 @then("the worker stops after the lifespan ends")
-def worker_stops(
-    app_with_worker: tuple[LifespanApp, dict[str, bool], asyncio.Event, asyncio.Event],
-) -> None:
+def worker_stops(app_with_worker: AppWithWorker) -> None:
     """Assert that the worker stopped after the lifespan context."""
     _, _, _, stopped = app_with_worker
     assert stopped.is_set()


### PR DESCRIPTION
## Summary
- mark WorkerController roadmap items complete
- add stop assertion for lifespan-managed workers
- share LifespanApp helper between tests and example and improve random status example

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make markdownlint`
- `make nixie` (fails: FileNotFound: failed copying files from cache)
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e386bee048322a9eb01247471a2e2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved example app lifecycle: eager startup initialization, graceful shutdown closing active WebSocket connections, and more robust connection error handling.

- Documentation
  - Updated roadmap to mark background worker integration tasks as completed.

- Tests
  - Added lifespan utility for tests and expanded scenarios to verify workers start during lifespan and stop afterward.
  - Introduced test package initializers for clearer structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->