### PR TITLE
Make WebSocketConnectionManager I/O methods asynchronous

### DIFF
--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -1079,9 +1079,8 @@ globals.
        return {}
    ```
 
-   A concrete signature signals that callers can rely on a plain dict and
-   keeps the hook symmetric with Falcon's HTTP-style `get_child_scope()`
-   patterns.
+   A concrete signature signals that callers can rely on a plain dict and keeps
+   the hook symmetric with Falcon's HTTP-style `get_child_scope()` patterns.
 
 2. **Shared state object**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -133,9 +133,9 @@ finalizes the connection manager API.
     for managing workers, completely removing the old `add_websocket_worker`
     concept.
 
-- [ ] **Finalize** `WebSocketConnectionManager` **API.**
+- [x] **Finalize** `WebSocketConnectionManager` **API.**
 
-  - [ ] Refactor all I/O methods (e.g., `broadcast_to_room`) to be `async def`
+  - [x] Refactor all I/O methods (e.g., `broadcast_to_room`) to be `async def`
     and ensure they propagate exceptions correctly.
 
   - [ ] Implement `async for` iterators (e.g., `conn_mgr.connections(room=...)`)

--- a/tests/behaviour/connection_manager.feature
+++ b/tests/behaviour/connection_manager.feature
@@ -4,3 +4,8 @@ Feature: WebSocket connection manager broadcasting
     Given a connection manager with two connections in room "lobby"
     When a message is broadcast to room "lobby"
     Then both connections receive that message
+
+  Scenario: broadcast message to a room with one connection excluded
+    Given a connection manager with two connections in room "lobby"
+    When a message is broadcast to room "lobby" excluding connection "a"
+    Then only connection "b" receives that message

--- a/tests/behaviour/connection_manager.feature
+++ b/tests/behaviour/connection_manager.feature
@@ -1,0 +1,6 @@
+Feature: WebSocket connection manager broadcasting
+
+  Scenario: broadcast message to all connections in a room
+    Given a connection manager with two connections in room "lobby"
+    When a message is broadcast to room "lobby"
+    Then both connections receive that message

--- a/tests/behaviour/test_connection_manager_steps.py
+++ b/tests/behaviour/test_connection_manager_steps.py
@@ -44,14 +44,20 @@ def test_broadcast() -> None:  # pragma: no cover - bdd registration
 )
 def setup_room() -> tuple[WebSocketConnectionManager, DummyWebSocket, DummyWebSocket]:
     """Create a connection manager prepopulated with a lobby room."""
-    mgr = WebSocketConnectionManager()
-    ws1 = DummyWebSocket(messages=[])
-    ws2 = DummyWebSocket(messages=[])
-    mgr.add_connection("a", ws1)
-    mgr.add_connection("b", ws2)
-    mgr.join_room("a", "lobby")
-    mgr.join_room("b", "lobby")
-    return mgr, ws1, ws2
+
+    async def _run() -> tuple[
+        WebSocketConnectionManager, DummyWebSocket, DummyWebSocket
+    ]:
+        mgr = WebSocketConnectionManager()
+        ws1 = DummyWebSocket(messages=[])
+        ws2 = DummyWebSocket(messages=[])
+        await mgr.add_connection("a", ws1)
+        await mgr.add_connection("b", ws2)
+        await mgr.join_room("a", "lobby")
+        await mgr.join_room("b", "lobby")
+        return mgr, ws1, ws2
+
+    return asyncio.run(_run())
 
 
 @when('a message is broadcast to room "lobby"')

--- a/tests/behaviour/test_connection_manager_steps.py
+++ b/tests/behaviour/test_connection_manager_steps.py
@@ -1,0 +1,77 @@
+"""Behaviour tests for the WebSocketConnectionManager."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses as dc
+
+from pytest_bdd import given, scenario, then, when
+
+from falcon_pachinko.websocket import WebSocketConnectionManager
+
+
+@dc.dataclass
+class DummyWebSocket:
+    """WebSocket stub that records messages."""
+
+    messages: list[object]
+
+    async def accept(
+        self, subprotocol: str | None = None
+    ) -> None:  # pragma: no cover - unused
+        """Accept the connection."""
+        return
+
+    async def close(self, code: int = 1000) -> None:  # pragma: no cover - unused
+        """Close the connection."""
+        return
+
+    async def send_media(self, data: object) -> None:
+        """Record sent data."""
+        self.messages.append(data)
+
+
+@scenario(
+    "connection_manager.feature", "broadcast message to all connections in a room"
+)
+def test_broadcast() -> None:  # pragma: no cover - bdd registration
+    """Scenario: broadcast message to all connections in a room."""
+
+
+@given(
+    'a connection manager with two connections in room "lobby"',
+    target_fixture="setup",
+)
+def setup_room() -> tuple[WebSocketConnectionManager, DummyWebSocket, DummyWebSocket]:
+    """Create a connection manager prepopulated with a lobby room."""
+    mgr = WebSocketConnectionManager()
+    ws1 = DummyWebSocket(messages=[])
+    ws2 = DummyWebSocket(messages=[])
+    mgr.add_connection("a", ws1)
+    mgr.add_connection("b", ws2)
+    mgr.join_room("a", "lobby")
+    mgr.join_room("b", "lobby")
+    return mgr, ws1, ws2
+
+
+@when('a message is broadcast to room "lobby"')
+def broadcast(
+    setup: tuple[WebSocketConnectionManager, DummyWebSocket, DummyWebSocket],
+) -> None:
+    """Broadcast a test message to the lobby room."""
+    mgr, _, _ = setup
+
+    async def _run() -> None:
+        await mgr.broadcast_to_room("lobby", {"msg": "hi"})
+
+    asyncio.run(_run())
+
+
+@then("both connections receive that message")
+def assert_received(
+    setup: tuple[WebSocketConnectionManager, DummyWebSocket, DummyWebSocket],
+) -> None:
+    """Assert that both connections received the broadcast."""
+    _, ws1, ws2 = setup
+    assert ws1.messages == [{"msg": "hi"}]
+    assert ws2.messages == [{"msg": "hi"}]

--- a/tests/test_connection_manager_unit.py
+++ b/tests/test_connection_manager_unit.py
@@ -121,6 +121,15 @@ async def test_broadcast_to_room_propagates_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_join_room_requires_known_connection() -> None:
+    """Joining a room with an unknown connection raises an error."""
+    mgr = WebSocketConnectionManager()
+
+    with pytest.raises(WebSocketConnectionNotFoundError):
+        await mgr.join_room("ghost", "lobby")
+
+
+@pytest.mark.asyncio
 async def test_send_to_unknown_connection_raises_key_error() -> None:
     """Sending to an unknown connection raises KeyError."""
     mgr = WebSocketConnectionManager()

--- a/tests/test_connection_manager_unit.py
+++ b/tests/test_connection_manager_unit.py
@@ -1,0 +1,93 @@
+"""Unit tests for the WebSocketConnectionManager."""
+
+from __future__ import annotations
+
+import pytest
+
+from falcon_pachinko.websocket import WebSocketConnectionManager
+
+
+class DummyWebSocket:
+    """Minimal WebSocket stub that records sent messages."""
+
+    def __init__(self) -> None:
+        self.messages: list[object] = []
+
+    async def accept(
+        self, subprotocol: str | None = None
+    ) -> None:  # pragma: no cover - not used
+        """Accept the connection."""
+        return
+
+    async def close(self, code: int = 1000) -> None:  # pragma: no cover - not used
+        """Close the connection."""
+        return
+
+    async def send_media(self, data: object) -> None:
+        """Record a message sent via the stub."""
+        self.messages.append(data)
+
+
+class ErrorWebSocket(DummyWebSocket):
+    """WebSocket stub whose send raises an error."""
+
+    async def send_media(
+        self, data: object
+    ) -> None:  # pragma: no cover - behaviour tested
+        """Raise to simulate a broken connection."""
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_send_to_connection_sends_message() -> None:
+    """Send a message to a single connection."""
+    mgr = WebSocketConnectionManager()
+    ws = DummyWebSocket()
+    mgr.add_connection("a", ws)
+
+    await mgr.send_to_connection("a", {"hello": "world"})
+
+    assert ws.messages == [{"hello": "world"}]
+
+
+@pytest.mark.asyncio
+async def test_send_to_connection_propagates_error() -> None:
+    """Errors raised by send_media bubble up."""
+    mgr = WebSocketConnectionManager()
+    ws = ErrorWebSocket()
+    mgr.add_connection("a", ws)
+
+    with pytest.raises(RuntimeError):
+        await mgr.send_to_connection("a", "ping")
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_room_sends_to_each_member() -> None:
+    """Broadcast to a room sends to all connections."""
+    mgr = WebSocketConnectionManager()
+    ws1 = DummyWebSocket()
+    ws2 = DummyWebSocket()
+    mgr.add_connection("a", ws1)
+    mgr.add_connection("b", ws2)
+    mgr.join_room("a", "lobby")
+    mgr.join_room("b", "lobby")
+
+    await mgr.broadcast_to_room("lobby", "hi")
+
+    assert ws1.messages == ["hi"]
+    assert ws2.messages == ["hi"]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_room_propagates_error() -> None:
+    """Broadcasting propagates errors from any connection."""
+    mgr = WebSocketConnectionManager()
+    ws1 = DummyWebSocket()
+    ws2 = ErrorWebSocket()
+    mgr.add_connection("a", ws1)
+    mgr.add_connection("b", ws2)
+    mgr.join_room("a", "lobby")
+    mgr.join_room("b", "lobby")
+
+    with pytest.raises(RuntimeError):
+        await mgr.broadcast_to_room("lobby", 42)


### PR DESCRIPTION
## Summary
- refactor `WebSocketConnectionManager` I/O helpers to async, allowing errors to surface
- add unit and behaviour tests covering the async connection manager
- mark roadmap item as complete

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: FileNotFound for mermaid CLI dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689ef49e79fc8322bebc749f7ade51b4

## Summary by Sourcery

Refactor WebSocketConnectionManager to support asynchronous I/O with proper locking and update tests and roadmap documentation

Enhancements:
- Convert connection manager I/O helpers (send_to_connection and broadcast_to_room) to async methods with a threading lock for safe concurrent access

Documentation:
- Mark WebSocketConnectionManager API roadmap item as complete

Tests:
- Add unit tests for async send, broadcast, and error propagation
- Add BDD behaviour tests for room broadcasting scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Upgraded WebSocket connection management to fully async with improved concurrency.
  - Support for joining/leaving rooms, targeted sends, and room-wide broadcasts with optional exclusions.
  - Clearer errors when attempting to send to non-existent connections.

- Documentation
  - Roadmap updated to mark two Phase 3 tasks as completed.

- Tests
  - Added behavior and unit tests covering room broadcasts, targeted sends, error propagation, and exclusions to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->