### PR TITLE
Add async iterator to WebSocketConnectionManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ async def handle_new_chat_message(self, ws, payload):
 ```
 
 Use ``conn_mgr.connections()`` to iterate over active websockets. The iterator
-captures a snapshot under a lock so the set can not mutate while iterating.
+captures a snapshot under a lock so the set cannot mutate while iterating.
 
 ```python
 import asyncio

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ async def heartbeat(*, conn_mgr):
     try:
         while True:
             # Snapshot to avoid mutation during iteration
-            conns = list(conn_mgr.connections.values())
+            conns = [ws async for ws in conn_mgr.connections()]
             if conns:
                 # Send concurrently; swallow per-connection errors
                 await asyncio.gather(

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ async def handle_new_chat_message(self, ws, payload):
     ...
 ```
 
-Use ``conn_mgr.connections()`` to iterate over active websockets. The iterator
-captures a snapshot under a lock so the set cannot mutate while iterating.
+Use ``conn_mgr.connections()`` to iterate over active WebSocket connections.
+The iterator captures a snapshot under a lock and then yields it, so iteration
+occurs over an immutable snapshot.
 
 ```python
 import asyncio

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ async def handle_new_chat_message(self, ws, payload):
     ...
 ```
 
+Use ``conn_mgr.connections()`` to iterate over active websockets. The iterator
+captures a snapshot under a lock so the set can not mutate while iterating.
+
 ```python
 import asyncio
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,7 +138,7 @@ finalizes the connection manager API.
   - [x] Refactor all I/O methods (e.g., `broadcast_to_room`) to be `async def`
     and ensure they propagate exceptions correctly.
 
-  - [ ] Implement `async for` iterators (e.g., `conn_mgr.connections(room=...)`)
+  - [x] Implement `async for` iterators (e.g., `conn_mgr.connections(room=...)`)
     for composable bulk operations.
 
   - [ ] Define the abstract backend interface (ABC) for the connection manager

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -172,7 +172,7 @@ class WebSocketConnectionManager:
         room: str,
         data: object,
         *,
-        exclude: typ.Container[str] | None = None,
+        exclude: typ.Collection[str] | None = None,
     ) -> None:
         """Send ``data`` to every connection in ``room``.
 
@@ -182,7 +182,7 @@ class WebSocketConnectionManager:
             Target room name.
         data : object
             Structured data to forward to each connection.
-        exclude : Container[str] | None, optional
+        exclude : Collection[str] | None, optional
             Connection IDs to skip. Unknown IDs are ignored.
         """
         async with self._lock:
@@ -213,7 +213,7 @@ class WebSocketConnectionManager:
     def _should_include_connection(
         self,
         conn_id: str,
-        exclude: typ.Container[str] | None,
+        exclude: typ.Collection[str] | None,
         *,
         strict: bool = True,
     ) -> bool:
@@ -226,7 +226,7 @@ class WebSocketConnectionManager:
     def _build_websocket_list(
         self,
         connection_ids: list[str],
-        exclude: typ.Container[str] | None,
+        exclude: typ.Collection[str] | None,
         *,
         strict: bool = True,
     ) -> list[WebSocketLike]:
@@ -241,7 +241,7 @@ class WebSocketConnectionManager:
         self,
         *,
         room: str | None = None,
-        exclude: typ.Container[str] | None = None,
+        exclude: typ.Collection[str] | None = None,
     ) -> typ.AsyncIterator[WebSocketLike]:
         """Yield websockets matching the given filters.
 
@@ -254,7 +254,7 @@ class WebSocketConnectionManager:
         ----------
         room : str | None, optional
             If provided, only yield connections that have joined this room.
-        exclude : Container[str] | None, optional
+        exclude : Collection[str] | None, optional
             Connection IDs to skip.
         """
         async with self._lock:

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -194,10 +194,18 @@ class WebSocketConnectionManager:
             return_exceptions=True,
         )
         errors = [exc for exc in results if isinstance(exc, Exception)]
+        self._handle_broadcast_errors(errors)
+
+    def _handle_broadcast_errors(self, errors: list[Exception]) -> None:
+        """Raise broadcast errors individually or as an aggregated group."""
         if not errors:
             return
         if len(errors) == 1:
             raise errors[0]
+        self._raise_exception_group(errors)
+
+    def _raise_exception_group(self, errors: list[Exception]) -> None:
+        """Raise ``errors`` as an :class:`ExceptionGroup` when available."""
         try:
             msg = "broadcast_to_room errors"
             raise ExceptionGroup(msg, errors)  # type: ignore[name-defined]

--- a/tests/behaviour/connection_manager.feature
+++ b/tests/behaviour/connection_manager.feature
@@ -14,3 +14,13 @@ Feature: WebSocket connection manager broadcasting
       Given a connection manager with two connections in room "lobby"
       When we iterate over connections in room "lobby"
       Then both connections are yielded
+
+    Scenario: iterate over connections in a room with one connection excluded
+      Given a connection manager with two connections in room "lobby"
+      When we iterate over connections in room "lobby" excluding connection "a"
+      Then only the non-excluded connection is yielded
+
+    Scenario: iterate over an empty room
+      Given a connection manager with no connections in room "lobby"
+      When we iterate over connections in room "lobby"
+      Then no connections are yielded for an empty room

--- a/tests/behaviour/connection_manager.feature
+++ b/tests/behaviour/connection_manager.feature
@@ -5,22 +5,22 @@ Feature: WebSocket connection manager broadcasting
     When a message is broadcast to room "lobby"
     Then both connections receive that message
 
-    Scenario: broadcast message to a room with one connection excluded
-      Given a connection manager with two connections in room "lobby"
-      When a message is broadcast to room "lobby" excluding connection "a"
-      Then only connection "b" receives that message
+  Scenario: broadcast message to a room with one connection excluded
+    Given a connection manager with two connections in room "lobby"
+    When a message is broadcast to room "lobby" excluding connection "a"
+    Then only connection "b" receives that message
 
-    Scenario: iterate over connections in a room
-      Given a connection manager with two connections in room "lobby"
-      When we iterate over connections in room "lobby"
-      Then both connections are yielded
+  Scenario: iterate over connections in a room
+    Given a connection manager with two connections in room "lobby"
+    When we iterate over connections in room "lobby"
+    Then both connections are yielded
 
-    Scenario: iterate over connections in a room with one connection excluded
-      Given a connection manager with two connections in room "lobby"
-      When we iterate over connections in room "lobby" excluding connection "a"
-      Then only the non-excluded connection is yielded
+  Scenario: iterate over connections in a room with one connection excluded
+    Given a connection manager with two connections in room "lobby"
+    When we iterate over connections in room "lobby" excluding connection "a"
+    Then only the non-excluded connection is yielded
 
-    Scenario: iterate over an empty room
-      Given a connection manager with no connections in room "lobby"
-      When we iterate over connections in room "lobby"
-      Then no connections are yielded for an empty room
+  Scenario: iterate over an empty room
+    Given a connection manager with no connections in room "lobby"
+    When we iterate over connections in room "lobby"
+    Then no connections are yielded for an empty room

--- a/tests/behaviour/connection_manager.feature
+++ b/tests/behaviour/connection_manager.feature
@@ -5,7 +5,12 @@ Feature: WebSocket connection manager broadcasting
     When a message is broadcast to room "lobby"
     Then both connections receive that message
 
-  Scenario: broadcast message to a room with one connection excluded
-    Given a connection manager with two connections in room "lobby"
-    When a message is broadcast to room "lobby" excluding connection "a"
-    Then only connection "b" receives that message
+    Scenario: broadcast message to a room with one connection excluded
+      Given a connection manager with two connections in room "lobby"
+      When a message is broadcast to room "lobby" excluding connection "a"
+      Then only connection "b" receives that message
+
+    Scenario: iterate over connections in a room
+      Given a connection manager with two connections in room "lobby"
+      When we iterate over connections in room "lobby"
+      Then both connections are yielded

--- a/tests/behaviour/test_connection_manager_steps.py
+++ b/tests/behaviour/test_connection_manager_steps.py
@@ -134,7 +134,10 @@ def setup_room() -> SetupFixture:
     target_fixture="setup",
 )
 def setup_empty_room() -> SetupFixture:
-    """Create a connection manager with an empty lobby room."""
+    """Create a connection manager with an empty lobby room.
+
+    Note: ``ws1``/``ws2`` are placeholders to satisfy ``SetupFixture`` shape.
+    """
     loop = asyncio.new_event_loop()
     try:
         asyncio.set_event_loop(loop)

--- a/tests/test_connection_manager_unit.py
+++ b/tests/test_connection_manager_unit.py
@@ -136,3 +136,31 @@ async def test_send_to_unknown_connection_raises_key_error() -> None:
 
     with pytest.raises(WebSocketConnectionNotFoundError):
         await mgr.send_to_connection("a", "hi")
+
+
+@pytest.mark.asyncio
+async def test_connections_iterates_all(
+    room_with_two_connections: tuple[
+        WebSocketConnectionManager, DummyWebSocket, DummyWebSocket
+    ],
+) -> None:
+    """Iterating without a room yields all connections."""
+    mgr, ws1, ws2 = room_with_two_connections
+
+    seen = [ws async for ws in mgr.connections()]
+
+    assert set(seen) == {ws1, ws2}
+
+
+@pytest.mark.asyncio
+async def test_connections_iterates_room_with_exclusion(
+    room_with_two_connections: tuple[
+        WebSocketConnectionManager, DummyWebSocket, DummyWebSocket
+    ],
+) -> None:
+    """Iterating a room honours the exclusion list."""
+    mgr, _, ws2 = room_with_two_connections
+
+    seen = [ws async for ws in mgr.connections(room="lobby", exclude={"a"})]
+
+    assert seen == [ws2]


### PR DESCRIPTION
## Summary
- add async `connections()` generator for bulk operations
- cover connection iteration with unit and BDD tests
- document iterator usage and update roadmap

## Testing
- `make lint`
- `make typecheck`
- `make markdownlint`
- `make nixie`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68ae191620a083229b93d0d6d6533ead

## Summary by Sourcery

Add an async iterator API for bulk operations on WebSocket connections and replace direct access to the connections mapping with the new iterator method.

New Features:
- Implement an async connections() generator that yields websockets filtered by room and exclusion list

Enhancements:
- Rename the internal connections dict to websockets and update all methods to reference it
- Replace direct access to the connections mapping in examples and server code with the async iterator

Documentation:
- Document the new async iterator usage in the README and update the roadmap to mark it complete

Tests:
- Add unit tests and BDD scenarios to verify connections() yields the correct websockets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async iteration over active connections with room and exclusion filters; new public APIs to register/unregister connections.

* **Refactor**
  * Connection management now uses managed access and snapshot iteration for broadcasts and shutdown; stronger validation for duplicate/unknown connections.

* **Examples**
  * Example server updated to use the new connection management workflow and graceful shutdown behavior.

* **Documentation**
  * Roadmap updated to mark async iterator support as implemented.

* **Tests**
  * Added behavior and unit tests covering iteration, filters, exclusions, and empty-room cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->