### PR TITLE
Add pluggable connection manager backend

### DIFF
--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -335,7 +335,7 @@ avoids a monolithic receive loop with extensive conditional logic.
      `@handles_message` decorator should be used. This is the preferred method
      as it is not subject to potential ambiguities with non-standard tag names.
 
-  1. **By Convention (Convenience)**: As a convenience, a handler can be defined
+  2. **By Convention (Convenience)**: As a convenience, a handler can be defined
      by creating a method named `on_{type_discriminator}`. The framework will
      attempt to convert `CamelCase` and `grazingCamelCase` discriminators to
      `snake_case` to form the method name (e.g., a message with
@@ -440,6 +440,9 @@ backend interface to support both single-process and distributed deployments.
     `broadcast_to_room`, `send_to_connection`) will be coroutines (`async def`)
     and will propagate exceptions. This ensures that network failures or
     backend errors are not silent.
+
+  - **Bounded Broadcasts**: `broadcast_to_room` accepts an optional per-send
+    timeout to mitigate slow recipients.
 
   - **Async Iterators**: For bulk operations, the manager will expose async
     iterators, making them highly composable.
@@ -1153,8 +1156,8 @@ schema-driven approach.
 
 #### 5.3.1. Declaring Message Schemas
 
-A resource defines its message schema using a `typ.Union` of
-`ms.Struct` types, where each `Struct` represents a distinct message.
+A resource defines its message schema using a `typ.Union` of `ms.Struct` types,
+where each `Struct` represents a distinct message.
 
 ```python
 import msgspec as ms

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -335,12 +335,20 @@ avoids a monolithic receive loop with extensive conditional logic.
      `@handles_message` decorator should be used. This is the preferred method
      as it is not subject to potential ambiguities with non-standard tag names.
 
-  2. **By Convention (Convenience)**: As a convenience, a handler can be defined
-     by creating a method named `on_{type_discriminator}`. The framework will
-     attempt to convert `CamelCase` and `grazingCamelCase` discriminators to
-     `snake_case` to form the method name (e.g., a message with
-     `"type": "userTyping"` would be dispatched to `on_user_typing`). This is
-     less robust for non-ASCII or complex (e.g., dotted) tags.
+  2. **By Convention (Convenience)**: As a convenience, a handler can be
+     defined by creating a method named `on_{type_discriminator}`. The
+     framework applies a best-effort conversion that:
+
+     - Lowercases the discriminator and converts ASCII camelCase/PascalCase to
+       `snake_case`.
+     - Replaces any non-alphanumeric characters (including non-ASCII glyphs and
+       dotted segments) with underscores.
+
+     When both a decorator registration and a convention match exist, the
+     decorator wins. Convention-based handlers always use strict payload
+     validation; opting into `strict=False` requires the decorator form.
+     Consequently, the naming convention remains best-effort and is primarily
+     suited to simple ASCII tags.
 
   ```python
   from falcon_pachinko import WebSocketLike, WebSocketResource, handles_message
@@ -442,7 +450,12 @@ backend interface to support both single-process and distributed deployments.
     backend errors are not silent.
 
   - **Bounded Broadcasts**: `broadcast_to_room` accepts an optional per-send
-    timeout to mitigate slow recipients.
+    timeout (in seconds) to mitigate slow recipients. A value of ``0`` forces
+    an immediate timeout. When individual sends fail or time out, the manager
+    aggregates the exceptions, raising the original error or an
+    ``ExceptionGroup`` when multiple recipients fail. Applications should
+    choose a timeout aligned with their backpressure strategy (e.g., smaller
+    values for large rooms paired with a retry queue).
 
   - **Async Iterators**: For bulk operations, the manager will expose async
     iterators, making them highly composable.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -141,10 +141,10 @@ finalizes the connection manager API.
   - [x] Implement `async for` iterators (e.g., `conn_mgr.connections(room=...)`)
     for composable bulk operations.
 
-  - [ ] Define the abstract backend interface (ABC) for the connection manager
+  - [x] Define the abstract backend interface (ABC) for the connection manager
     to pave the way for future distributed backends.
 
-  - [ ] Ensure the default `InProcessBackend` correctly implements this new,
+  - [x] Ensure the default `InProcessBackend` correctly implements this new,
     robust interface.
 
 ## Phase 4: Cross-Cutting Concerns

--- a/falcon_pachinko/__init__.py
+++ b/falcon_pachinko/__init__.py
@@ -6,10 +6,17 @@ from .handlers import handles_message
 from .protocols import WebSocketLike
 from .resource import WebSocketResource
 from .router import WebSocketRouter
-from .websocket import WebSocketConnectionManager, install
+from .websocket import (
+    ConnectionBackend,
+    InProcessBackend,
+    WebSocketConnectionManager,
+    install,
+)
 from .workers import WorkerController, worker
 
 __all__ = (
+    "ConnectionBackend",
+    "InProcessBackend",
     "WebSocketConnectionManager",
     "WebSocketLike",
     "WebSocketResource",

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -153,8 +153,9 @@ class InProcessBackend(ConnectionBackend):
 
     @property
     def websockets(self) -> typ.Mapping[str, WebSocketLike]:
-        """Read-only mapping of connection IDs to WebSocket objects."""
-        return types.MappingProxyType(self._websockets)
+        """Read-only snapshot of connection IDs to WebSocket objects."""
+        snapshot = self._websockets.copy()
+        return types.MappingProxyType(snapshot)
 
     @property
     def rooms(self) -> typ.Mapping[str, frozenset[str]]:

--- a/falcon_pachinko/websocket.py
+++ b/falcon_pachinko/websocket.py
@@ -9,6 +9,7 @@ approach is documented in :doc:`falcon-websocket-extension-design`.
 
 from __future__ import annotations
 
+import abc
 import asyncio
 import dataclasses as dc
 import typing as typ
@@ -93,76 +94,164 @@ class RouteSpec:
     kwargs: dict[str, typ.Any] = dc.field(default_factory=_kwargs_factory)
 
 
-class WebSocketConnectionManager:
-    """Track active WebSocket connections and group them into rooms.
+class ConnectionBackend(abc.ABC):
+    """Abstract interface for connection manager backends."""
 
-    ``websockets`` maps each connection ID to the underlying
-    ``falcon.asgi.WebSocket`` object for server-initiated messaging. The
-    :py:meth:`connections` iterator yields a snapshot of this mapping captured
-    under an internal lock so that it cannot mutate during iteration. The
-    name ``connections()`` is therefore reserved for this iterator API.
+    @property
+    @abc.abstractmethod
+    def websockets(self) -> typ.Mapping[str, WebSocketLike]:
+        """Mapping of connection IDs to local WebSocket objects."""
 
-    ``rooms`` maps room names to sets of connection IDs so that multiple
-    clients can be addressed at once. A single connection may join any number
-    of rooms.
+    @property
+    @abc.abstractmethod
+    def rooms(self) -> typ.Mapping[str, set[str]]:
+        """Mapping of room names to sets of connection IDs."""
 
-    The initial implementation is an in-process store, but the class is
-    designed to evolve into a pluggable backend so that distributed
-    deployments can share state. Implementations MUST guard concurrent
-    access. The in-process version is task-safe within a single event loop
-    via :class:`asyncio.Lock`; using the same instance across multiple threads
-    or event loops is not supported.
-    """
+    @abc.abstractmethod
+    async def add_connection(self, conn_id: str, ws: WebSocketLike) -> None:
+        """Register a new connection."""
+
+    @abc.abstractmethod
+    async def remove_connection(self, conn_id: str) -> None:
+        """Remove a connection and purge memberships."""
+
+    @abc.abstractmethod
+    async def join_room(self, conn_id: str, room: str) -> None:
+        """Add ``conn_id`` to ``room``."""
+
+    @abc.abstractmethod
+    async def leave_room(self, conn_id: str, room: str) -> None:
+        """Remove ``conn_id`` from ``room``."""
+
+    @abc.abstractmethod
+    async def get_websocket(self, conn_id: str) -> WebSocketLike | None:
+        """Return websocket for ``conn_id`` if present."""
+
+    @abc.abstractmethod
+    async def snapshot(
+        self, room: str | None = None
+    ) -> list[tuple[str, WebSocketLike]]:
+        """Return snapshot of (conn_id, websocket) pairs."""
+
+
+class InProcessBackend(ConnectionBackend):
+    """Task-safe in-memory backend."""
 
     def __init__(self) -> None:
-        """Initialize the WebSocketConnectionManager with empty mappings."""
-        # Track WebSocket objects by connection ID. The mapping is exposed
-        # via ``websockets`` to reserve ``connections()`` for the async
-        # iterator API.
-        self.websockets: dict[str, WebSocketLike] = {}
-        self.rooms: dict[str, set[str]] = {}
+        self._websockets: dict[str, WebSocketLike] = {}
+        self._rooms: dict[str, set[str]] = {}
         self._lock = asyncio.Lock()
 
+    @property
+    def websockets(self) -> dict[str, WebSocketLike]:
+        """Return mapping of connection IDs to WebSocket objects."""
+        return self._websockets
+
+    @property
+    def rooms(self) -> dict[str, set[str]]:
+        """Return mapping of room names to member IDs."""
+        return self._rooms
+
     async def add_connection(self, conn_id: str, ws: WebSocketLike) -> None:
-        """Register a new WebSocket connection."""
+        """Register a new connection."""
         async with self._lock:
-            if conn_id in self.websockets:
-                raise ValueError(f"Duplicate connection ID: {conn_id!r}")  # noqa: TRY003
-            self.websockets[conn_id] = ws
+            if conn_id in self._websockets:
+                msg = f"Duplicate connection ID: {conn_id!r}"
+                raise ValueError(msg)
+            self._websockets[conn_id] = ws
 
     async def remove_connection(self, conn_id: str) -> None:
-        """Remove a WebSocket connection and purge room memberships."""
+        """Remove a connection and clean up room memberships."""
         async with self._lock:
-            self.websockets.pop(conn_id, None)
-            empty_rooms: list[str] = []
-            for room, members in self.rooms.items():
+            self._websockets.pop(conn_id, None)
+            empty: list[str] = []
+            for room, members in self._rooms.items():
                 members.discard(conn_id)
                 if not members:
-                    empty_rooms.append(room)
-            for room in empty_rooms:
-                self.rooms.pop(room, None)
+                    empty.append(room)
+            for room in empty:
+                self._rooms.pop(room, None)
 
     async def join_room(self, conn_id: str, room: str) -> None:
-        """Add a connection to the given room."""
+        """Add ``conn_id`` to ``room``."""
         async with self._lock:
-            if conn_id not in self.websockets:
+            if conn_id not in self._websockets:
                 raise WebSocketConnectionNotFoundError(conn_id)
-            self.rooms.setdefault(room, set()).add(conn_id)
+            self._rooms.setdefault(room, set()).add(conn_id)
 
     async def leave_room(self, conn_id: str, room: str) -> None:
-        """Remove a connection from the given room."""
+        """Remove ``conn_id`` from ``room`` if present."""
         async with self._lock:
-            members = self.rooms.get(room)
+            members = self._rooms.get(room)
             if not members:
                 return
             members.discard(conn_id)
             if not members:
-                self.rooms.pop(room, None)
+                self._rooms.pop(room, None)
+
+    async def get_websocket(self, conn_id: str) -> WebSocketLike | None:
+        """Return websocket for ``conn_id`` if known."""
+        async with self._lock:
+            return self._websockets.get(conn_id)
+
+    async def snapshot(
+        self, room: str | None = None
+    ) -> list[tuple[str, WebSocketLike]]:
+        """Return snapshot of websockets for ``room`` or all."""
+        async with self._lock:
+            if room is None:
+                items = list(self._websockets.items())
+            else:
+                ids = list(self._rooms.get(room, set()))
+                items = []
+                for cid in ids:
+                    ws = self._websockets.get(cid)
+                    if ws is None:
+                        raise WebSocketConnectionNotFoundError(cid)
+                    items.append((cid, ws))
+        return items
+
+
+class WebSocketConnectionManager:
+    """Track active WebSocket connections and group them into rooms.
+
+    WebSocketConnectionManager now delegates storage to a pluggable backend
+    so that deployments may swap in distributed implementations without
+    changing application code.
+    """
+
+    def __init__(self, backend: ConnectionBackend | None = None) -> None:
+        self._backend = backend or InProcessBackend()
+
+    @property
+    def websockets(self) -> typ.Mapping[str, WebSocketLike]:
+        """Expose backend websocket mapping."""
+        return self._backend.websockets
+
+    @property
+    def rooms(self) -> typ.Mapping[str, set[str]]:
+        """Expose backend room membership mapping."""
+        return self._backend.rooms
+
+    async def add_connection(self, conn_id: str, ws: WebSocketLike) -> None:
+        """Register a connection with the backend."""
+        await self._backend.add_connection(conn_id, ws)
+
+    async def remove_connection(self, conn_id: str) -> None:
+        """Forget a connection and its room memberships."""
+        await self._backend.remove_connection(conn_id)
+
+    async def join_room(self, conn_id: str, room: str) -> None:
+        """Add an existing connection to ``room``."""
+        await self._backend.join_room(conn_id, room)
+
+    async def leave_room(self, conn_id: str, room: str) -> None:
+        """Remove ``conn_id`` from ``room`` if present."""
+        await self._backend.leave_room(conn_id, room)
 
     async def send_to_connection(self, conn_id: str, data: object) -> None:
-        """Send ``data`` to a specific connection by ID."""
-        async with self._lock:
-            ws = self.websockets.get(conn_id)
+        """Send ``data`` to a single connection."""
+        ws = await self._backend.get_websocket(conn_id)
         if ws is None:
             raise WebSocketConnectionNotFoundError(conn_id)
         await ws.send_media(data)
@@ -174,20 +263,9 @@ class WebSocketConnectionManager:
         *,
         exclude: typ.Collection[str] | None = None,
     ) -> None:
-        """Send ``data`` to every connection in ``room``.
-
-        Parameters
-        ----------
-        room : str
-            Target room name.
-        data : object
-            Structured data to forward to each connection.
-        exclude : Collection[str] | None, optional
-            Connection IDs to skip. Unknown IDs are ignored.
-        """
-        async with self._lock:
-            ids = list(self.rooms.get(room, set()))
-            websockets = self._build_websocket_list(ids, exclude, strict=False)
+        """Broadcast ``data`` to members of ``room``."""
+        snapshot = await self._backend.snapshot(room)
+        websockets = [ws for cid, ws in snapshot if not exclude or cid not in exclude]
 
         results = await asyncio.gather(
             *(ws.send_media(data) for ws in websockets),
@@ -197,7 +275,6 @@ class WebSocketConnectionManager:
         self._handle_broadcast_errors(errors)
 
     def _handle_broadcast_errors(self, errors: list[Exception]) -> None:
-        """Raise broadcast errors individually or as an aggregated group."""
         if not errors:
             return
         if len(errors) == 1:
@@ -205,45 +282,11 @@ class WebSocketConnectionManager:
         self._raise_exception_group(errors)
 
     def _raise_exception_group(self, errors: list[Exception]) -> None:
-        """Raise ``errors`` as an :class:`ExceptionGroup` when available."""
         try:
             msg = "broadcast_to_room errors"
             raise ExceptionGroup(msg, errors)  # type: ignore[name-defined]
         except NameError:  # pragma: no cover - fallback for older Pythons
             raise errors[0] from None
-
-    def _get_filtered_connection_ids(self, room: str | None) -> list[str]:
-        """Return connection IDs for all or a specific room."""
-        return (
-            list(self.websockets) if room is None else list(self.rooms.get(room, set()))
-        )
-
-    def _should_include_connection(
-        self,
-        conn_id: str,
-        exclude: typ.Collection[str] | None,
-        *,
-        strict: bool = True,
-    ) -> bool:
-        """Return True if the ID exists (or ``strict=False``) and is not excluded."""
-        exists = conn_id in self.websockets
-        if strict and not exists:
-            raise WebSocketConnectionNotFoundError(conn_id)
-        return exists and (not exclude or conn_id not in exclude)
-
-    def _build_websocket_list(
-        self,
-        connection_ids: list[str],
-        exclude: typ.Collection[str] | None,
-        *,
-        strict: bool = True,
-    ) -> list[WebSocketLike]:
-        """Return websockets corresponding to ``connection_ids``."""
-        return [
-            self.websockets[cid]
-            for cid in connection_ids
-            if self._should_include_connection(cid, exclude, strict=strict)
-        ]
 
     async def connections(
         self,
@@ -251,29 +294,11 @@ class WebSocketConnectionManager:
         room: str | None = None,
         exclude: typ.Collection[str] | None = None,
     ) -> typ.AsyncIterator[WebSocketLike]:
-        """Yield websockets matching the given filters.
-
-        This iterator captures a snapshot under a lock so that the underlying
-        mapping cannot change mid-iteration. Room membership is purged when a
-        connection disconnects; encountering an unknown ID therefore raises
-        :class:`WebSocketConnectionNotFoundError` and signals a corrupted state.
-
-        Parameters
-        ----------
-        room : str | None, optional
-            If provided, only yield connections that have joined this room.
-        exclude : Collection[str] | None, optional
-            Connection IDs to skip.
-        """
-        async with self._lock:
-            ids = self._get_filtered_connection_ids(room)
-            websockets = self._build_websocket_list(ids, exclude)
-
-        for ws in websockets:
-            yield ws
-
-
-# Public API ---------------------------------------------------------------
+        """Iterate over active connections matching ``room`` and ``exclude``."""
+        snapshot = await self._backend.snapshot(room)
+        for cid, ws in snapshot:
+            if not exclude or cid not in exclude:
+                yield ws
 
 
 def install(app: typ.Any) -> None:  # noqa: ANN401

--- a/tests/test_connection_manager_unit.py
+++ b/tests/test_connection_manager_unit.py
@@ -67,7 +67,7 @@ async def corrupt_room_membership(
     """Inject an unknown connection ID into a room for testing."""
     backend = typ.cast("InProcessBackend", mgr._backend)
     async with backend._lock:  # pragma: no cover - internal test helper
-        backend.rooms.setdefault(room, set()).add(ghost_id)
+        backend._rooms.setdefault(room, set()).add(ghost_id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection_manager_unit.py
+++ b/tests/test_connection_manager_unit.py
@@ -222,6 +222,17 @@ async def test_connections_raise_on_stale_room_member(
         _ = [ws async for ws in mgr.connections(room="lobby")]
 
 
+@pytest.mark.asyncio
+async def test_websockets_property_returns_snapshot() -> None:
+    """Exposing websockets returns a stable snapshot."""
+    mgr = WebSocketConnectionManager()
+    ws = DummyWebSocket()
+    await mgr.add_connection("a", ws)
+    snapshot = mgr.websockets
+    await mgr.add_connection("b", DummyWebSocket())
+    assert dict(snapshot) == {"a": ws}
+
+
 def test_default_backend_is_inprocess() -> None:
     """Ensure the default backend is used."""
     mgr = WebSocketConnectionManager()


### PR DESCRIPTION
## Summary
- define abstract connection backend interface for connection manager
- implement default InProcessBackend using the new interface
- test default backend and document roadmap progress

## Testing
- `make fmt`
- `make lint`
- `make typecheck`
- `make markdownlint`
- `make nixie`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c5d2dfa083228afc49dd342b3cb7

## Summary by Sourcery

Add a pluggable backend architecture by defining ConnectionBackend ABC and providing an InProcessBackend implementation, refactor the connection manager to use this backend, update exports, tests, and roadmap documentation

New Features:
- Introduce ConnectionBackend abstract interface for connection management
- Implement InProcessBackend as the default in-memory ConnectionBackend

Enhancements:
- Refactor WebSocketConnectionManager to delegate storage and operations to a pluggable backend
- Streamline broadcasting and connection iteration using backend.snapshot and get_websocket

Documentation:
- Mark backend interface and InProcessBackend implementation as completed in the roadmap

Tests:
- Adapt unit tests to exercise the new backend API and add test for default backend type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable backend for WebSocket connections with a default in-process backend.
  * Connection and room listings exposed as read-only snapshots.
  * Broadcasts support per-send timeouts and backend-driven iteration.
  * New public exports: ConnectionBackend and InProcessBackend.

* **Documentation**
  * Roadmap updated to mark the backend interface and default implementation as completed.
  * Design doc: added guidance on bounded broadcasts.

* **Tests**
  * Added tests for error aggregation in broadcasts and snapshot stability of websockets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->