### PR TITLE
Implement multi-tier WebSocket hook system

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -152,14 +152,14 @@ finalizes the connection manager API.
 This phase adds the essential features for building production-grade
 applications.
 
-- [ ] **Implement the Multi-Tiered Hook System.**
+- [x] **Implement the Multi-Tiered Hook System.**
 
-  - [ ] Create a `HookManager` to orchestrate hook execution.
+  - [x] Create a `HookManager` to orchestrate hook execution.
 
-  - [ ] Add support for global hooks on `WebSocketRouter` and per-resource hooks
+  - [x] Add support for global hooks on `WebSocketRouter` and per-resource hooks
     on `WebSocketResource`.
 
-  - [ ] Implement the "onion-style" execution order (outermost hooks run first)
+  - [x] Implement the "onion-style" execution order (outermost hooks run first)
     and define the error propagation behaviour for exceptions raised within the
     hook chain.
 

--- a/falcon_pachinko/__init__.py
+++ b/falcon_pachinko/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .handlers import handles_message
+from .hooks import HookCollection, HookContext, HookManager
 from .protocols import WebSocketLike
 from .resource import WebSocketResource
 from .router import WebSocketRouter
@@ -16,6 +17,9 @@ from .workers import WorkerController, worker
 
 __all__ = (
     "ConnectionBackend",
+    "HookCollection",
+    "HookContext",
+    "HookManager",
     "InProcessBackend",
     "WebSocketConnectionManager",
     "WebSocketLike",

--- a/falcon_pachinko/behaviour/features/hooks.feature
+++ b/falcon_pachinko/behaviour/features/hooks.feature
@@ -1,0 +1,7 @@
+Feature: Hook execution order
+  Scenario: Global and resource hooks wrap lifecycle
+    Given a router with multi-tier hooks
+    When a client connects and sends a message
+    Then the hook log should show layered connect order
+    And the hook log should show layered receive order
+    And the child resource records hook-injected params

--- a/falcon_pachinko/behaviour/test_hooks_behaviour.py
+++ b/falcon_pachinko/behaviour/test_hooks_behaviour.py
@@ -1,0 +1,175 @@
+"""Behavioural tests for the hook orchestration system."""
+
+from __future__ import annotations
+
+import asyncio
+import typing as typ
+from types import SimpleNamespace
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+from falcon_pachinko import (
+    HookCollection,
+    HookContext,
+    WebSocketResource,
+    WebSocketRouter,
+)
+from falcon_pachinko.unittests.helpers import DummyWS
+
+EVENTS: list[str] = []
+
+
+class HookedChild(WebSocketResource):
+    """Child resource used to verify hook ordering."""
+
+    instances: typ.ClassVar[list[HookedChild]] = []
+
+    def __init__(self) -> None:
+        HookedChild.instances.append(self)
+
+    async def on_connect(self, req: object, ws: object, **params: object) -> bool:
+        """Accept the connection and retain the provided params."""
+        self.params = params
+        return True
+
+    async def on_unhandled(self, ws: object, message: str | bytes) -> None:
+        """Record unhandled messages to observe hook ordering."""
+        EVENTS.append("handler.child")
+
+
+class HookedParent(WebSocketResource):
+    """Parent resource that mounts :class:`HookedChild`."""
+
+    def __init__(self) -> None:
+        self.add_subroute("child", HookedChild)
+
+
+async def global_hook(context: HookContext) -> None:
+    """Record global hook invocations and mutate connect params."""
+    EVENTS.append(f"global.{context.event}")
+    if context.event == "before_connect":
+        if context.params is None:
+            context.params = {}
+        context.params.setdefault("global", True)
+    if context.event == "after_connect":
+        assert context.result is True
+    if context.event == "after_receive":
+        assert context.error is None
+
+
+async def parent_hook(context: HookContext) -> None:
+    """Capture parent-level hooks for ordering assertions."""
+    EVENTS.append(f"parent.{context.event}")
+    if context.event == "before_connect":
+        if context.params is None:
+            context.params = {}
+        context.params.setdefault("parent", True)
+    if context.event == "after_receive":
+        assert context.error is None
+
+
+async def child_hook(context: HookContext) -> None:
+    """Capture child-level hooks for ordering assertions."""
+    EVENTS.append(f"child.{context.event}")
+    if context.event == "before_receive":
+        assert context.raw == b'{"type":"noop"}'
+    if context.event == "after_receive":
+        assert context.error is None
+
+
+@scenario("features/hooks.feature", "Global and resource hooks wrap lifecycle")
+def test_hooks_feature() -> None:
+    """Scenario placeholder for pytest-bdd."""
+
+
+def _reset_hooks() -> None:
+    HookedParent.hooks = HookCollection()
+    HookedChild.hooks = HookCollection()
+
+
+@pytest.fixture
+def context() -> dict[str, typ.Any]:
+    """Scenario-scoped context object used for step communication."""
+
+    return {}
+
+
+@given("a router with multi-tier hooks")
+def given_router(context: dict[str, typ.Any]) -> None:
+    """Prepare a router with global and resource hooks."""
+    EVENTS.clear()
+    HookedChild.instances.clear()
+    _reset_hooks()
+
+    router = WebSocketRouter()
+    router.global_hooks.add("before_connect", global_hook)
+    router.global_hooks.add("after_connect", global_hook)
+    router.global_hooks.add("before_receive", global_hook)
+    router.global_hooks.add("after_receive", global_hook)
+
+    HookedParent.hooks.add("before_connect", parent_hook)
+    HookedParent.hooks.add("after_connect", parent_hook)
+    HookedParent.hooks.add("before_receive", parent_hook)
+    HookedParent.hooks.add("after_receive", parent_hook)
+
+    HookedChild.hooks.add("before_connect", child_hook)
+    HookedChild.hooks.add("after_connect", child_hook)
+    HookedChild.hooks.add("before_receive", child_hook)
+    HookedChild.hooks.add("after_receive", child_hook)
+
+    router.add_route("/hooks", HookedParent)
+    router.mount("/")
+    context["router"] = router
+
+
+@when("a client connects and sends a message")
+def when_client_connects(context: dict[str, typ.Any]) -> None:
+    """Simulate a connection followed by a dispatched message."""
+    router: WebSocketRouter = context["router"]
+    ws = DummyWS()
+    req = SimpleNamespace(path="/hooks/child", path_template="")
+    asyncio.run(router.on_websocket(req, ws))
+
+    child = HookedChild.instances[-1]
+    context["child_params"] = child.params
+
+    asyncio.run(child.dispatch(ws, b'{"type":"noop"}'))
+    context["events"] = list(EVENTS)
+
+
+@then("the hook log should show layered connect order")
+def then_connect_order(context: dict[str, typ.Any]) -> None:
+    """Validate connect hook execution ordering."""
+    events: list[str] = context["events"]
+    assert events[:6] == [
+        "global.before_connect",
+        "parent.before_connect",
+        "child.before_connect",
+        "child.after_connect",
+        "parent.after_connect",
+        "global.after_connect",
+    ]
+
+
+@then("the hook log should show layered receive order")
+def then_receive_order(context: dict[str, typ.Any]) -> None:
+    """Validate receive hook execution ordering."""
+    events: list[str] = context["events"]
+    assert events[6:] == [
+        "global.before_receive",
+        "parent.before_receive",
+        "child.before_receive",
+        "handler.child",
+        "child.after_receive",
+        "parent.after_receive",
+        "global.after_receive",
+    ]
+
+
+@then("the child resource records hook-injected params")
+def then_child_params(context: dict[str, typ.Any]) -> None:
+    """Ensure context mutation from hooks reaches the child resource."""
+    params = context["child_params"]
+    assert params["global"] is True
+    assert params["parent"] is True

--- a/falcon_pachinko/hooks.py
+++ b/falcon_pachinko/hooks.py
@@ -1,0 +1,226 @@
+"""Utilities for registering and executing WebSocket lifecycle hooks.
+
+The multi-tiered hook system allows applications to register callbacks that
+wrap the WebSocket lifecycle at both the router (global) and resource levels.
+Hooks execute in an "onion-style" order so that outer layers (global hooks)
+run before inner ones and after hooks unwind in reverse order. This mirrors the
+design outlined in :mod:`docs/falcon-websocket-extension-design.md` and keeps
+cross-cutting concerns explicit and testable.
+"""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import inspect
+import typing as typ
+
+if typ.TYPE_CHECKING:  # pragma: no cover - imported for type hints only
+    import falcon
+
+    from .protocols import WebSocketLike
+    from .resource import WebSocketResource
+
+
+HookCallable = typ.Callable[["HookContext"], typ.Awaitable[None] | None]
+
+_SUPPORTED_EVENTS = (
+    "before_connect",
+    "after_connect",
+    "before_receive",
+    "after_receive",
+    "before_disconnect",
+)
+
+
+@dc.dataclass(slots=True)
+class HookContext:
+    """Context object passed to hook callbacks.
+
+    Parameters
+    ----------
+    event:
+        Name of the lifecycle event currently being processed.
+    target:
+        The innermost resource for the current connection or message.
+    resource:
+        The resource whose hooks are executing. ``None`` for global hooks.
+    req:
+        Request associated with the connection attempt. Only populated for
+        connection hooks.
+    ws:
+        WebSocket instance associated with the event.
+    params:
+        Route parameters passed to :meth:`WebSocketResource.on_connect`.
+    raw:
+        Raw message payload supplied to :meth:`WebSocketResource.dispatch`.
+    result:
+        Result produced by the wrapped handler, such as the boolean returned by
+        ``on_connect``. ``None`` if not applicable.
+    error:
+        Exception raised by the wrapped handler, if any.
+    close_code:
+        Optional close code supplied when a disconnect hook fires.
+    """
+
+    event: str
+    target: WebSocketResource
+    resource: WebSocketResource | None
+    req: falcon.Request | None = None
+    ws: WebSocketLike | None = None
+    params: dict[str, object] | None = None
+    raw: str | bytes | None = None
+    result: bool | None = None
+    error: BaseException | None = None
+    close_code: int | None = None
+
+
+class HookCollection:
+    """Registry for lifecycle hooks tied to a particular scope."""
+
+    def __init__(self, initial: dict[str, list[HookCallable]] | None = None) -> None:
+        self._registry: dict[str, list[HookCallable]] = {
+            event: list(initial.get(event, ())) if initial else []
+            for event in _SUPPORTED_EVENTS
+        }
+
+    def add(self, event: str, hook: HookCallable) -> None:
+        """Register ``hook`` for the given ``event``."""
+        if event not in _SUPPORTED_EVENTS:
+            msg = f"Unsupported hook event: {event!r}"
+            raise ValueError(msg)
+        if not callable(hook):
+            msg = "hook must be callable"
+            raise TypeError(msg)
+        self._registry[event].append(hook)
+
+    def iter(self, event: str) -> tuple[HookCallable, ...]:
+        """Return the hooks registered for ``event``."""
+        if event not in _SUPPORTED_EVENTS:
+            msg = f"Unsupported hook event: {event!r}"
+            raise ValueError(msg)
+        return tuple(self._registry[event])
+
+    @classmethod
+    def clone_from(cls, other: HookCollection | None) -> HookCollection:
+        """Return a deep copy of ``other`` or an empty collection."""
+        if other is None:
+            return cls()
+        return cls({event: list(other._registry[event]) for event in _SUPPORTED_EVENTS})
+
+
+class HookManager:
+    """Coordinate hook execution across router and resource tiers."""
+
+    def __init__(
+        self,
+        *,
+        global_hooks: HookCollection,
+        resources: typ.Sequence[WebSocketResource],
+    ) -> None:
+        if not resources:
+            msg = "HookManager requires at least one resource"
+            raise ValueError(msg)
+        self._global_hooks = global_hooks
+        self._resources = tuple(resources)
+        self._index = {
+            id(resource): idx for idx, resource in enumerate(self._resources)
+        }
+
+    def _iter_resources(
+        self, target: WebSocketResource
+    ) -> tuple[WebSocketResource, ...]:
+        try:
+            idx = self._index[id(target)]
+        except KeyError as exc:  # pragma: no cover - defensive programming
+            msg = "target resource not managed by this HookManager"
+            raise ValueError(msg) from exc
+        return self._resources[: idx + 1]
+
+    async def _invoke(
+        self, hooks: tuple[HookCallable, ...], context: HookContext
+    ) -> None:
+        for hook in hooks:
+            result = hook(context)
+            if inspect.isawaitable(result):
+                await typ.cast("typ.Awaitable[None]", result)
+
+    async def _run_before(self, event: str, context: HookContext) -> None:
+        context.resource = None
+        await self._invoke(self._global_hooks.iter(event), context)
+        for resource in self._iter_resources(context.target):
+            context.resource = resource
+            await self._invoke(resource.hooks.iter(event), context)
+        context.resource = None
+
+    async def _run_after(self, event: str, context: HookContext) -> None:
+        for resource in reversed(self._iter_resources(context.target)):
+            context.resource = resource
+            await self._invoke(resource.hooks.iter(event), context)
+        context.resource = None
+        await self._invoke(self._global_hooks.iter(event), context)
+
+    async def notify_before_connect(
+        self,
+        target: WebSocketResource,
+        *,
+        req: falcon.Request,
+        ws: WebSocketLike,
+        params: dict[str, object],
+    ) -> HookContext:
+        """Fire ``before_connect`` hooks and return the shared context."""
+        context = HookContext(
+            event="before_connect",
+            target=target,
+            resource=None,
+            req=req,
+            ws=ws,
+            params=params,
+        )
+        await self._run_before("before_connect", context)
+        return context
+
+    async def notify_after_connect(self, context: HookContext) -> None:
+        """Run ``after_connect`` hooks using ``context``."""
+        context.event = "after_connect"
+        await self._run_after("after_connect", context)
+
+    async def notify_before_receive(
+        self,
+        target: WebSocketResource,
+        *,
+        ws: WebSocketLike,
+        raw: str | bytes,
+    ) -> HookContext:
+        """Run ``before_receive`` hooks and return the shared context."""
+        context = HookContext(
+            event="before_receive",
+            target=target,
+            resource=None,
+            ws=ws,
+            raw=raw,
+        )
+        await self._run_before("before_receive", context)
+        return context
+
+    async def notify_after_receive(self, context: HookContext) -> None:
+        """Run ``after_receive`` hooks using ``context``."""
+        context.event = "after_receive"
+        await self._run_after("after_receive", context)
+
+    async def notify_before_disconnect(
+        self,
+        target: WebSocketResource,
+        *,
+        ws: WebSocketLike,
+        close_code: int,
+    ) -> HookContext:
+        """Run ``before_disconnect`` hooks and return the shared context."""
+        context = HookContext(
+            event="before_disconnect",
+            target=target,
+            resource=None,
+            ws=ws,
+            close_code=close_code,
+        )
+        await self._run_before("before_disconnect", context)
+        return context

--- a/falcon_pachinko/unittests/test_hooks.py
+++ b/falcon_pachinko/unittests/test_hooks.py
@@ -1,0 +1,172 @@
+"""Unit tests covering the hook manager orchestration."""
+
+from __future__ import annotations
+
+import typing as typ
+
+import pytest
+
+from falcon_pachinko import HookContext, WebSocketResource, WebSocketRouter
+from falcon_pachinko.unittests.helpers import DummyWS
+
+
+@pytest.mark.asyncio
+async def test_hook_order_and_context() -> None:
+    """Global and resource hooks execute in layered order."""
+    events: list[str] = []
+
+    class HookChild(WebSocketResource):
+        """Child resource that records hook context."""
+
+        instances: typ.ClassVar[list[HookChild]] = []
+
+        def __init__(self) -> None:
+            HookChild.instances.append(self)
+
+        async def on_connect(self, req: object, ws: object, **params: object) -> bool:
+            self.params = params
+            return True
+
+        async def on_unhandled(self, ws: object, message: str | bytes) -> None:
+            events.append("handler.child")
+
+    class HookParent(WebSocketResource):
+        """Parent resource that mounts ``HookChild``."""
+
+        instances: typ.ClassVar[list[HookParent]] = []
+
+        def __init__(self) -> None:
+            HookParent.instances.append(self)
+            self.add_subroute("child", HookChild)
+
+    async def global_hook(context: HookContext) -> None:
+        assert isinstance(context.target, HookChild)
+        if context.event == "before_connect":
+            if context.params is None:
+                context.params = {}
+            context.params.setdefault("global", True)
+        if context.event == "after_connect":
+            assert context.result is True
+        if context.event == "after_receive":
+            assert context.error is None
+        events.append(f"global.{context.event}")
+
+    async def parent_hook(context: HookContext) -> None:
+        assert context.resource in HookParent.instances
+        if context.event == "before_connect":
+            if context.params is None:
+                context.params = {}
+            context.params.setdefault("parent", True)
+        if context.event == "after_receive":
+            assert context.error is None
+        events.append(f"parent.{context.event}")
+
+    async def child_hook(context: HookContext) -> None:
+        assert isinstance(context.target, HookChild)
+        if context.event == "after_connect":
+            assert context.result is True
+        if context.event == "before_receive":
+            assert context.raw == b'{"type":"noop"}'
+        if context.event == "after_receive":
+            assert context.error is None
+        events.append(f"child.{context.event}")
+
+    router = WebSocketRouter()
+    router.global_hooks.add("before_connect", global_hook)
+    router.global_hooks.add("after_connect", global_hook)
+    router.global_hooks.add("before_receive", global_hook)
+    router.global_hooks.add("after_receive", global_hook)
+
+    HookParent.hooks.add("before_connect", parent_hook)
+    HookParent.hooks.add("after_connect", parent_hook)
+    HookParent.hooks.add("before_receive", parent_hook)
+    HookParent.hooks.add("after_receive", parent_hook)
+
+    HookChild.hooks.add("before_connect", child_hook)
+    HookChild.hooks.add("after_connect", child_hook)
+    HookChild.hooks.add("before_receive", child_hook)
+    HookChild.hooks.add("after_receive", child_hook)
+
+    router.add_route("/hooks", HookParent)
+    router.mount("/")
+
+    ws = DummyWS()
+    req = type("Req", (), {"path": "/hooks/child", "path_template": ""})()
+    await router.on_websocket(req, ws)
+
+    child = HookChild.instances[-1]
+    assert child.params["global"] is True
+    assert child.params["parent"] is True
+
+    await child.dispatch(ws, b'{"type":"noop"}')
+
+    assert events == [
+        "global.before_connect",
+        "parent.before_connect",
+        "child.before_connect",
+        "child.after_connect",
+        "parent.after_connect",
+        "global.after_connect",
+        "global.before_receive",
+        "parent.before_receive",
+        "child.before_receive",
+        "handler.child",
+        "child.after_receive",
+        "parent.after_receive",
+        "global.after_receive",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_after_receive_reports_errors() -> None:
+    """After hooks receive the raised exception."""
+    events: list[tuple[str, str]] = []
+
+    class BoomResource(WebSocketResource):
+        instances: typ.ClassVar[list[BoomResource]] = []
+
+        def __init__(self) -> None:
+            BoomResource.instances.append(self)
+
+        async def on_connect(self, req: object, ws: object, **params: object) -> bool:
+            return True
+
+        async def on_boom(self, ws: object, payload: object) -> None:
+            raise RuntimeError("boom")
+
+    async def global_hook(context: HookContext) -> None:
+        events.append(("global", context.event))
+        if context.event == "after_receive":
+            assert isinstance(context.error, RuntimeError)
+
+    async def resource_hook(context: HookContext) -> None:
+        events.append(("resource", context.event))
+        if context.event == "before_receive":
+            assert context.raw == b'{"type":"boom"}'
+        if context.event == "after_receive":
+            assert isinstance(context.error, RuntimeError)
+
+    router = WebSocketRouter()
+    router.global_hooks.add("before_receive", global_hook)
+    router.global_hooks.add("after_receive", global_hook)
+
+    BoomResource.hooks.add("before_receive", resource_hook)
+    BoomResource.hooks.add("after_receive", resource_hook)
+
+    router.add_route("/boom", BoomResource)
+    router.mount("/")
+
+    ws = DummyWS()
+    req = type("Req", (), {"path": "/boom", "path_template": ""})()
+    await router.on_websocket(req, ws)
+
+    resource = BoomResource.instances[-1]
+    with pytest.raises(RuntimeError):
+        await resource.dispatch(ws, b'{"type":"boom"}')
+
+    assert events == [
+        ("global", "before_receive"),
+        ("resource", "before_receive"),
+        ("resource", "after_receive"),
+        ("global", "after_receive"),
+    ]


### PR DESCRIPTION
## Summary
- add a HookManager, HookCollection, and HookContext to drive multi-tier WebSocket lifecycle hooks
- integrate the hook manager with router and resource dispatch logic and export the new types
- cover the hook system with unit and behaviour tests and update the roadmap milestone

## Testing
- make fmt
- make lint
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68c990bb92988322b5b52947b6394f0b