### PR TITLE
Refactor hook tests for lower complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ See
 [docs/falcon-websocket-extension-design.md](docs/falcon-websocket-extension-design.md)
  for the full design rationale.
 
+## Requirements
+
+- Python 3.12 or newer
+
 ## Key features
 
 - `app.add_websocket_route()` maps WebSocket paths to `WebSocketResource`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -152,14 +152,14 @@ finalizes the connection manager API.
 This phase adds the essential features for building production-grade
 applications.
 
-- [ ] **Implement the Multi-Tiered Hook System.**
+- [x] **Implement the Multi-Tiered Hook System.**
 
-  - [ ] Create a `HookManager` to orchestrate hook execution.
+  - [x] Create a `HookManager` to orchestrate hook execution.
 
-  - [ ] Add support for global hooks on `WebSocketRouter` and per-resource hooks
+  - [x] Add support for global hooks on `WebSocketRouter` and per-resource hooks
     on `WebSocketResource`.
 
-  - [ ] Implement the "onion-style" execution order (outermost hooks run first)
+  - [x] Implement the "onion-style" execution order (outermost hooks run first)
     and define the error propagation behaviour for exceptions raised within the
     hook chain.
 

--- a/falcon_pachinko/__init__.py
+++ b/falcon_pachinko/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .handlers import handles_message
+from .hooks import HookCollection, HookContext, HookManager
 from .protocols import WebSocketLike
 from .resource import WebSocketResource
 from .router import WebSocketRouter
@@ -16,6 +17,9 @@ from .workers import WorkerController, worker
 
 __all__ = (
     "ConnectionBackend",
+    "HookCollection",
+    "HookContext",
+    "HookManager",
     "InProcessBackend",
     "WebSocketConnectionManager",
     "WebSocketLike",

--- a/falcon_pachinko/behaviour/features/hooks.feature
+++ b/falcon_pachinko/behaviour/features/hooks.feature
@@ -6,6 +6,11 @@ Feature: Hook execution order
     And the hook log should show layered receive order
     And the child resource records hook-injected params
 
+  Scenario: Router global hooks fire without resource hooks
+    Given a router with only global hooks
+    When a client connects and sends a message
+    Then only global hooks are recorded
+
   Scenario: Errors propagate through after hooks
     Given a router with multi-tier hooks
     When a client connects and sends a message that triggers an error

--- a/falcon_pachinko/behaviour/features/hooks.feature
+++ b/falcon_pachinko/behaviour/features/hooks.feature
@@ -1,0 +1,12 @@
+Feature: Hook execution order
+  Scenario: Global and resource hooks wrap lifecycle
+    Given a router with multi-tier hooks
+    When a client connects and sends a message
+    Then the hook log should show layered connect order
+    And the hook log should show layered receive order
+    And the child resource records hook-injected params
+
+  Scenario: Errors propagate through after hooks
+    Given a router with multi-tier hooks
+    When a client connects and sends a message that triggers an error
+    Then the error is propagated to after_receive hook and the hook chain remains intact

--- a/falcon_pachinko/behaviour/test_hooks_behaviour.py
+++ b/falcon_pachinko/behaviour/test_hooks_behaviour.py
@@ -1,0 +1,257 @@
+"""Behavioural tests for the hook orchestration system."""
+
+from __future__ import annotations
+
+import asyncio
+import typing as typ
+from types import SimpleNamespace
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+from falcon_pachinko import (
+    HookCollection,
+    HookContext,
+    WebSocketResource,
+    WebSocketRouter,
+)
+from falcon_pachinko.unittests.helpers import DummyWS
+
+EVENTS: list[str] = []
+AFTER_RECEIVE_ERRORS: list[tuple[str, BaseException | None]] = []
+
+
+class HookedChild(WebSocketResource):
+    """Child resource used to verify hook ordering."""
+
+    instances: typ.ClassVar[list[HookedChild]] = []
+
+    def __init__(self) -> None:
+        HookedChild.instances.append(self)
+
+    async def on_connect(self, req: object, ws: object, **params: object) -> bool:
+        """Accept the connection and retain the provided params."""
+        self.params = params
+        return True
+
+    async def on_unhandled(self, ws: object, message: str | bytes) -> None:
+        """Record unhandled messages to observe hook ordering."""
+        EVENTS.append("handler.child")
+
+    async def on_error(self, ws: object, payload: object | None) -> None:
+        """Raise an error to exercise hook propagation."""
+        raise ValueError
+
+
+class HookedParent(WebSocketResource):
+    """Parent resource that mounts :class:`HookedChild`."""
+
+    def __init__(self) -> None:
+        self.add_subroute("child", HookedChild)
+
+
+async def global_hook(context: HookContext) -> None:
+    """Record global hook invocations and mutate connect params."""
+    EVENTS.append(f"global.{context.event}")
+    if context.event == "before_connect":
+        if context.params is None:
+            context.params = {}
+        context.params.setdefault("global", True)
+    elif context.event == "after_connect":
+        assert context.result is True
+    elif context.event == "after_receive":
+        AFTER_RECEIVE_ERRORS.append(("global", context.error))
+
+
+async def parent_hook(context: HookContext) -> None:
+    """Capture parent-level hooks for ordering assertions."""
+    EVENTS.append(f"parent.{context.event}")
+    if context.event == "before_connect":
+        if context.params is None:
+            context.params = {}
+        context.params.setdefault("parent", True)
+    elif context.event == "after_receive":
+        AFTER_RECEIVE_ERRORS.append(("parent", context.error))
+
+
+async def child_hook(context: HookContext) -> None:
+    """Capture child-level hooks for ordering assertions."""
+    EVENTS.append(f"child.{context.event}")
+    if context.event == "before_receive":
+        assert context.raw is not None
+    elif context.event == "after_receive":
+        AFTER_RECEIVE_ERRORS.append(("child", context.error))
+
+
+@scenario("features/hooks.feature", "Global and resource hooks wrap lifecycle")
+def test_hooks_feature() -> None:
+    """Scenario placeholder for pytest-bdd."""
+
+
+@pytest.fixture(autouse=True)
+def reset_hooks() -> typ.Iterator[None]:
+    """Reset hook registries and accumulated events between scenarios."""
+    HookedParent.hooks = HookCollection.inherit(WebSocketResource.hooks)
+    HookedChild.hooks = HookCollection.inherit(WebSocketResource.hooks)
+    HookedChild.instances.clear()
+    EVENTS.clear()
+    AFTER_RECEIVE_ERRORS.clear()
+    yield
+    HookedParent.hooks = HookCollection.inherit(WebSocketResource.hooks)
+    HookedChild.hooks = HookCollection.inherit(WebSocketResource.hooks)
+    HookedChild.instances.clear()
+    EVENTS.clear()
+    AFTER_RECEIVE_ERRORS.clear()
+
+
+@pytest.fixture
+def context() -> dict[str, typ.Any]:
+    """Scenario-scoped context object used for step communication."""
+    return {}
+
+
+def _assert_event_sequence(
+    context: dict[str, typ.Any],
+    start_idx: int,
+    end_idx: int | None,
+    expected_events: list[str],
+) -> None:
+    """Helper function to validate event sequence ordering."""  # noqa: D401
+    events: list[str] = context["events"]
+    actual_slice = events[start_idx:] if end_idx is None else events[start_idx:end_idx]
+    assert actual_slice == expected_events
+
+
+@given("a router with multi-tier hooks")
+def given_router(context: dict[str, typ.Any]) -> None:
+    """Prepare a router with global and resource hooks."""
+    router = WebSocketRouter()
+    router.global_hooks.add("before_connect", global_hook)
+    router.global_hooks.add("after_connect", global_hook)
+    router.global_hooks.add("before_receive", global_hook)
+    router.global_hooks.add("after_receive", global_hook)
+
+    HookedParent.hooks.add("before_connect", parent_hook)
+    HookedParent.hooks.add("after_connect", parent_hook)
+    HookedParent.hooks.add("before_receive", parent_hook)
+    HookedParent.hooks.add("after_receive", parent_hook)
+
+    HookedChild.hooks.add("before_connect", child_hook)
+    HookedChild.hooks.add("after_connect", child_hook)
+    HookedChild.hooks.add("before_receive", child_hook)
+    HookedChild.hooks.add("after_receive", child_hook)
+
+    router.add_route("/hooks", HookedParent)
+    router.mount("/")
+    context["router"] = router
+
+
+@when("a client connects and sends a message")
+def when_client_connects(context: dict[str, typ.Any]) -> None:
+    """Simulate a connection followed by a dispatched message."""
+    router: WebSocketRouter = context["router"]
+    ws = DummyWS()
+    req = SimpleNamespace(path="/hooks/child", path_template="")
+    asyncio.run(router.on_websocket(req, ws))
+
+    child = HookedChild.instances[-1]
+    context["child_params"] = child.params
+
+    asyncio.run(child.dispatch(ws, b'{"type":"noop"}'))
+    context["events"] = list(EVENTS)
+    context["after_errors"] = list(AFTER_RECEIVE_ERRORS)
+
+
+@when("a client connects and sends a message that triggers an error")
+def when_client_connects_with_error(context: dict[str, typ.Any]) -> None:
+    """Simulate a connection followed by a dispatched message that raises."""
+    router: WebSocketRouter = context["router"]
+    ws = DummyWS()
+    req = SimpleNamespace(path="/hooks/child", path_template="")
+    asyncio.run(router.on_websocket(req, ws))
+
+    child = HookedChild.instances[-1]
+    context["child_params"] = child.params
+
+    try:
+        asyncio.run(child.dispatch(ws, b'{"type":"error"}'))
+    except Exception as exc:  # noqa: BLE001 - surface the raised error
+        context["error"] = exc
+
+    context["events"] = list(EVENTS)
+    context["after_errors"] = list(AFTER_RECEIVE_ERRORS)
+
+
+@then("the hook log should show layered connect order")
+def then_connect_order(context: dict[str, typ.Any]) -> None:
+    """Validate connect hook execution ordering."""
+    _assert_event_sequence(
+        context,
+        0,
+        6,
+        [
+            "global.before_connect",
+            "parent.before_connect",
+            "child.before_connect",
+            "child.after_connect",
+            "parent.after_connect",
+            "global.after_connect",
+        ],
+    )
+
+
+@then("the hook log should show layered receive order")
+def then_receive_order(context: dict[str, typ.Any]) -> None:
+    """Validate receive hook execution ordering."""
+    _assert_event_sequence(
+        context,
+        6,
+        None,
+        [
+            "global.before_receive",
+            "parent.before_receive",
+            "child.before_receive",
+            "handler.child",
+            "child.after_receive",
+            "parent.after_receive",
+            "global.after_receive",
+        ],
+    )
+    assert context["after_errors"] == [
+        ("child", None),
+        ("parent", None),
+        ("global", None),
+    ]
+
+
+@then("the child resource records hook-injected params")
+def then_child_params(context: dict[str, typ.Any]) -> None:
+    """Ensure context mutation from hooks reaches the child resource."""
+    params = context["child_params"]
+    assert params["global"] is True
+    assert params["parent"] is True
+
+
+@scenario(
+    "features/hooks.feature",
+    "Errors propagate through after hooks",
+)
+def test_hooks_error_feature() -> None:
+    """Scenario placeholder for pytest-bdd error propagation."""
+
+
+@then("the error is propagated to after_receive hook and the hook chain remains intact")
+def then_error_propagates(context: dict[str, typ.Any]) -> None:
+    """Verify that after hooks observed the raised error in order."""
+    assert "error" in context
+    assert isinstance(context["error"], ValueError)
+    assert context["events"][-3:] == [
+        "child.after_receive",
+        "parent.after_receive",
+        "global.after_receive",
+    ]
+    assert context["after_errors"] == [
+        ("child", context["error"]),
+        ("parent", context["error"]),
+        ("global", context["error"]),
+    ]

--- a/falcon_pachinko/hooks.py
+++ b/falcon_pachinko/hooks.py
@@ -194,6 +194,19 @@ class HookManager:
                     await typ.cast("typ.Awaitable[None]", result)
         context.resource = None
 
+    def _prepare_hook_context(
+        self,
+        event: str,
+        target: WebSocketResource,
+        context: HookContext | None = None,
+        **kwargs: Unpack[_HookContextKwargs],
+    ) -> HookContext:
+        """Create or update hook context for the given event."""
+        if context is None:
+            return HookContext(event=event, target=target, resource=None, **kwargs)
+        context.event = event
+        return context
+
     async def _dispatch_event(
         self,
         event: str,
@@ -204,11 +217,7 @@ class HookManager:
         **kwargs: Unpack[_HookContextKwargs],
     ) -> HookContext:
         """Create or reuse ``context`` before executing ``event`` hooks."""
-        ctx = context
-        if ctx is None:
-            ctx = HookContext(event=event, target=target, resource=None, **kwargs)
-        else:
-            ctx.event = event
+        ctx = self._prepare_hook_context(event, target, context, **kwargs)
         await self._run_hooks(event, ctx, reverse=reverse)
         return ctx
 

--- a/falcon_pachinko/hooks.py
+++ b/falcon_pachinko/hooks.py
@@ -1,0 +1,239 @@
+"""Utilities for registering and executing WebSocket lifecycle hooks.
+
+The multi-tiered hook system allows applications to register callbacks that
+wrap the WebSocket lifecycle at both the router (global) and resource levels.
+Hooks execute in an "onion-style" order so that outer layers (global hooks)
+run before inner ones and after hooks unwind in reverse order. This mirrors the
+design outlined in :mod:`docs/falcon-websocket-extension-design.md` and keeps
+cross-cutting concerns explicit and testable.
+"""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import inspect
+import typing as typ
+
+if typ.TYPE_CHECKING:  # pragma: no cover - imported for type hints only
+    import falcon
+
+    from .protocols import WebSocketLike
+    from .resource import WebSocketResource
+
+
+HookCallable = typ.Callable[["HookContext"], typ.Awaitable[None] | None]
+
+_SUPPORTED_EVENTS = (
+    "before_connect",
+    "after_connect",
+    "before_receive",
+    "after_receive",
+    "before_disconnect",
+)
+
+
+@dc.dataclass(slots=True)
+class HookContext:
+    """Context object passed to hook callbacks.
+
+    Parameters
+    ----------
+    event:
+        Name of the lifecycle event currently being processed.
+    target:
+        The innermost resource for the current connection or message.
+    resource:
+        The resource whose hooks are executing. ``None`` for global hooks.
+    req:
+        Request associated with the connection attempt. Only populated for
+        connection hooks.
+    ws:
+        WebSocket instance associated with the event.
+    params:
+        Route parameters passed to :meth:`WebSocketResource.on_connect`.
+    raw:
+        Raw message payload supplied to :meth:`WebSocketResource.dispatch`.
+    result:
+        Result produced by the wrapped handler, such as the boolean returned by
+        ``on_connect``. ``None`` if not applicable.
+    error:
+        Exception raised by the wrapped handler, if any.
+    close_code:
+        Optional close code supplied when a disconnect hook fires.
+    """
+
+    event: str
+    target: WebSocketResource
+    resource: WebSocketResource | None
+    req: falcon.Request | None = None
+    ws: WebSocketLike | None = None
+    params: dict[str, object] | None = None
+    raw: str | bytes | None = None
+    result: bool | None = None
+    error: BaseException | None = None
+    close_code: int | None = None
+
+
+class HookCollection:
+    """Registry for lifecycle hooks tied to a particular scope."""
+
+    def __init__(
+        self,
+        initial: dict[str, list[HookCallable]] | None = None,
+        *,
+        parent: HookCollection | None = None,
+    ) -> None:
+        self._registry: dict[str, list[HookCallable]] = {
+            event: list(initial.get(event, ())) if initial else []
+            for event in _SUPPORTED_EVENTS
+        }
+        self._parent: HookCollection | None = parent
+
+    def add(self, event: str, hook: HookCallable) -> None:
+        """Register ``hook`` for the given ``event``."""
+        if event not in _SUPPORTED_EVENTS:
+            msg = f"Unsupported hook event: {event!r}"
+            raise ValueError(msg)
+        if not callable(hook):
+            msg = "hook must be callable"
+            raise TypeError(msg)
+        self._registry[event].append(hook)
+
+    def iter(self, event: str) -> tuple[HookCallable, ...]:
+        """Return the hooks registered for ``event``."""
+        if event not in _SUPPORTED_EVENTS:
+            msg = f"Unsupported hook event: {event!r}"
+            raise ValueError(msg)
+        local = tuple(self._registry[event])
+        if self._parent is None:
+            return local
+        parent_hooks = self._parent.iter(event)
+        if not parent_hooks:
+            return local
+        return parent_hooks + local
+
+    @classmethod
+    def clone_from(cls, other: HookCollection | None) -> HookCollection:
+        """Return a deep copy of ``other`` or an empty collection."""
+        if other is None:
+            return cls()
+        return cls(
+            {event: list(other._registry[event]) for event in _SUPPORTED_EVENTS},
+            parent=other._parent,
+        )
+
+    @classmethod
+    def inherit(cls, parent: HookCollection | None) -> HookCollection:
+        """Return a new collection whose iteration includes ``parent`` hooks."""
+        return cls(parent=parent)
+
+
+class HookManager:
+    """Coordinate hook execution across router and resource tiers."""
+
+    def __init__(
+        self,
+        *,
+        global_hooks: HookCollection,
+        resources: typ.Sequence[WebSocketResource],
+    ) -> None:
+        if not resources:
+            msg = "HookManager requires at least one resource"
+            raise ValueError(msg)
+        self._global_hooks = global_hooks
+        self._resources = list(resources)
+
+    def _build_layers(
+        self, target: WebSocketResource, event: str
+    ) -> list[tuple[WebSocketResource | None, tuple[HookCallable, ...]]]:
+        layers: list[tuple[WebSocketResource | None, tuple[HookCallable, ...]]] = [
+            (None, self._global_hooks.iter(event))
+        ]
+        for resource in self._resources:
+            layers.append((resource, resource.hooks.iter(event)))
+            if resource is target:
+                break
+        else:  # pragma: no cover - defensive programming
+            msg = "target resource not managed by this HookManager"
+            raise ValueError(msg)
+        return layers
+
+    async def _run_hooks(
+        self, event: str, context: HookContext, *, reverse: bool = False
+    ) -> None:
+        layers = self._build_layers(context.target, event)
+        if reverse:
+            layers.reverse()
+        for resource, hooks in layers:
+            context.resource = resource
+            for hook in hooks:
+                result = hook(context)
+                if inspect.isawaitable(result):
+                    await typ.cast("typ.Awaitable[None]", result)
+        context.resource = None
+
+    async def notify_before_connect(
+        self,
+        target: WebSocketResource,
+        *,
+        req: falcon.Request,
+        ws: WebSocketLike,
+        params: dict[str, object],
+    ) -> HookContext:
+        """Fire ``before_connect`` hooks and return the shared context."""
+        context = HookContext(
+            event="before_connect",
+            target=target,
+            resource=None,
+            req=req,
+            ws=ws,
+            params=params,
+        )
+        await self._run_hooks("before_connect", context)
+        return context
+
+    async def notify_after_connect(self, context: HookContext) -> None:
+        """Run ``after_connect`` hooks using ``context``."""
+        context.event = "after_connect"
+        await self._run_hooks("after_connect", context, reverse=True)
+
+    async def notify_before_receive(
+        self,
+        target: WebSocketResource,
+        *,
+        ws: WebSocketLike,
+        raw: str | bytes,
+    ) -> HookContext:
+        """Run ``before_receive`` hooks and return the shared context."""
+        context = HookContext(
+            event="before_receive",
+            target=target,
+            resource=None,
+            ws=ws,
+            raw=raw,
+        )
+        await self._run_hooks("before_receive", context)
+        return context
+
+    async def notify_after_receive(self, context: HookContext) -> None:
+        """Run ``after_receive`` hooks using ``context``."""
+        context.event = "after_receive"
+        await self._run_hooks("after_receive", context, reverse=True)
+
+    async def notify_before_disconnect(
+        self,
+        target: WebSocketResource,
+        *,
+        ws: WebSocketLike,
+        close_code: int,
+    ) -> HookContext:
+        """Run ``before_disconnect`` hooks and return the shared context."""
+        context = HookContext(
+            event="before_disconnect",
+            target=target,
+            resource=None,
+            ws=ws,
+            close_code=close_code,
+        )
+        await self._run_hooks("before_disconnect", context)
+        return context

--- a/falcon_pachinko/hooks.py
+++ b/falcon_pachinko/hooks.py
@@ -198,8 +198,8 @@ class HookManager:
     async def _dispatch_event(
         self,
         event: str,
-        *,
         target: WebSocketResource,
+        *,
         reverse: bool = False,
         context: HookContext | None = None,
         **kwargs: Unpack[_HookContextKwargs],
@@ -215,7 +215,7 @@ class HookManager:
         target: WebSocketResource,
         **kwargs: Unpack[_HookContextKwargs],
     ) -> HookContext:
-        """Dispatch before-* lifecycle events."""
+        """Helper to dispatch before-* lifecycle events."""  # noqa: D401
         return await self._dispatch_event(event, target=target, **kwargs)
 
     async def notify_before_connect(

--- a/falcon_pachinko/hooks.py
+++ b/falcon_pachinko/hooks.py
@@ -159,33 +159,21 @@ class HookManager:
     async def _run_hooks(
         self, event: str, context: HookContext, *, reverse: bool = False
     ) -> None:
-        layers = self._build_execution_layers(event, context.target)
-        if reverse:
-            layers.reverse()
-
-        await self._execute_layer_hooks(layers, context)
-
-    def _build_execution_layers(
-        self, event: str, target: WebSocketResource
-    ) -> list[tuple[WebSocketResource | None, tuple[HookCallable, ...]]]:
-        """Build the execution layers from global hooks to target resource."""
-        layers = [(None, self._global_hooks.iter(event))]
+        layers: list[tuple[WebSocketResource | None, tuple[HookCallable, ...]]] = [
+            (None, self._global_hooks.iter(event))
+        ]
 
         for resource in self._resources:
             layers.append((resource, resource.hooks.iter(event)))
-            if resource is target:
-                return layers
+            if resource is context.target:
+                break
+        else:
+            msg = "target resource not managed by this HookManager"
+            raise ValueError(msg)
 
-        # Target resource not found in managed resources
-        msg = "target resource not managed by this HookManager"
-        raise ValueError(msg)
+        if reverse:
+            layers.reverse()
 
-    async def _execute_layer_hooks(
-        self,
-        layers: list[tuple[WebSocketResource | None, tuple[HookCallable, ...]]],
-        context: HookContext,
-    ) -> None:
-        """Execute all hooks across the provided layers."""
         for resource, hooks in layers:
             context.resource = resource
             for hook in hooks:

--- a/falcon_pachinko/hooks.py
+++ b/falcon_pachinko/hooks.py
@@ -103,7 +103,6 @@ class HookCollection:
             for event in _SUPPORTED_EVENTS
         }
         self._parent: HookCollection | None = parent
-        self._versions: dict[str, int] = dict.fromkeys(_SUPPORTED_EVENTS, 0)
 
     def add(self, event: str, hook: HookCallable) -> None:
         """Register ``hook`` for the given ``event``."""
@@ -114,7 +113,6 @@ class HookCollection:
             msg = "hook must be callable"
             raise TypeError(msg)
         self._registry[event].append(hook)
-        self._versions[event] += 1
 
     def iter(self, event: str) -> tuple[HookCallable, ...]:
         """Return the hooks registered for ``event``."""
@@ -125,25 +123,10 @@ class HookCollection:
         parent_hooks = self._parent.iter(event) if self._parent is not None else ()
         return parent_hooks + local
 
-    def version(self, event: str) -> int:
-        """Return the mutation counter for ``event`` hooks."""
-        if event not in _SUPPORTED_EVENTS:
-            msg = f"Unsupported hook event: {event!r}"
-            raise ValueError(msg)
-        return self._versions[event]
-
     @classmethod
     def inherit(cls, parent: HookCollection | None) -> HookCollection:
         """Return a new collection whose iteration includes ``parent`` hooks."""
         return cls(parent=parent)
-
-
-@dc.dataclass(slots=True)
-class _HookLayerCacheEntry:
-    """Cached hook execution layers and their mutation tokens."""
-
-    layers: tuple[tuple[WebSocketResource | None, tuple[HookCallable, ...]], ...]
-    tokens: tuple[int, ...]
 
 
 class HookManager:
@@ -160,51 +143,24 @@ class HookManager:
             raise ValueError(msg)
         self._global_hooks = global_hooks
         self._resources = list(resources)
-        self._resource_indices: dict[WebSocketResource, int] = {
-            resource: index for index, resource in enumerate(self._resources)
-        }
-        self._layer_cache: dict[
-            tuple[str, WebSocketResource],
-            _HookLayerCacheEntry,
-        ] = {}
 
     async def _run_hooks(
         self, event: str, context: HookContext, *, reverse: bool = False
     ) -> None:
-        layers = self._build_execution_layers(event, context.target)
-        if reverse:
-            layers = tuple(reversed(layers))
-        await self._execute_layer_hooks(layers, context)
-        return
-
-    def _build_execution_layers(
-        self, event: str, target: WebSocketResource
-    ) -> tuple[tuple[WebSocketResource | None, tuple[HookCallable, ...]], ...]:
-        """Build the execution layers from global hooks to target resource."""
-        cache_key = (event, target)
-        cached = self._layer_cache.get(cache_key)
-
-        try:
-            index = self._resource_indices[target]
-        except KeyError as exc:  # pragma: no cover - defensive guard
+        layers: list[tuple[WebSocketResource | None, tuple[HookCallable, ...]]] = [
+            (None, self._global_hooks.iter(event))
+        ]
+        for resource in self._resources:
+            layers.append((resource, resource.hooks.iter(event)))
+            if resource is context.target:
+                break
+        else:  # pragma: no cover - defensive guard
             msg = "target resource not managed by this HookManager"
-            raise ValueError(msg) from exc
+            raise ValueError(msg)
 
-        tokens = self._layer_signature(event, index)
-        if cached is not None and cached.tokens == tokens:
-            return cached.layers
+        if reverse:
+            layers.reverse()
 
-        layers = self._construct_layers(event, index)
-        entry = _HookLayerCacheEntry(layers=layers, tokens=tokens)
-        self._layer_cache[cache_key] = entry
-        return entry.layers
-
-    async def _execute_layer_hooks(
-        self,
-        layers: typ.Sequence[tuple[WebSocketResource | None, tuple[HookCallable, ...]]],
-        context: HookContext,
-    ) -> None:
-        """Execute all hooks across the provided layers."""
         for resource, hooks in layers:
             context.resource = resource
             for hook in hooks:
@@ -213,27 +169,6 @@ class HookManager:
                     await typ.cast("typ.Awaitable[None]", result)
         context.resource = None
         return
-
-    def _layer_signature(self, event: str, index: int) -> tuple[int, ...]:
-        """Return mutation counters for global and resource hooks."""
-        tokens = [self._global_hooks.version(event)]
-        tokens.extend(
-            self._resources[position].hooks.version(event)
-            for position in range(index + 1)
-        )
-        return tuple(tokens)
-
-    def _construct_layers(
-        self, event: str, index: int
-    ) -> tuple[tuple[WebSocketResource | None, tuple[HookCallable, ...]], ...]:
-        """Materialize hook layers for ``event`` up to ``index``."""
-        layers: list[tuple[WebSocketResource | None, tuple[HookCallable, ...]]] = [
-            (None, self._global_hooks.iter(event))
-        ]
-        for position in range(index + 1):
-            resource = self._resources[position]
-            layers.append((resource, resource.hooks.iter(event)))
-        return tuple(layers)
 
     async def _notify_before_event(
         self,

--- a/falcon_pachinko/hooks.py
+++ b/falcon_pachinko/hooks.py
@@ -27,24 +27,7 @@ if typ.TYPE_CHECKING:  # pragma: no cover - imported for type hints only
 HookCallable = typ.Callable[["HookContext"], typ.Awaitable[None] | None]
 
 
-if typ.TYPE_CHECKING:
-
-    class _StrEnumBase(str, enum.Enum):
-        """Type-checking base when :class:`enum.StrEnum` is unavailable."""
-
-        pass
-else:
-    try:
-        _StrEnumBase = typ.cast("type[enum.Enum]", enum.StrEnum)  # type: ignore[attr-defined]
-    except AttributeError:  # pragma: no cover - executed only on Python < 3.11
-
-        class _StrEnumBase(str, enum.Enum):
-            """Compatibility shim when :class:`enum.StrEnum` is unavailable."""
-
-            pass
-
-
-class HookEvent(_StrEnumBase):
+class HookEvent(enum.StrEnum):
     """Supported WebSocket lifecycle hook events."""
 
     BEFORE_CONNECT = "before_connect"

--- a/falcon_pachinko/hooks.py
+++ b/falcon_pachinko/hooks.py
@@ -199,6 +199,15 @@ class HookManager:
         await self._run_hooks(event, ctx, reverse=reverse)
         return ctx
 
+    async def _notify_before_event(
+        self,
+        event: str,
+        target: WebSocketResource,
+        **kwargs: Unpack[_HookContextKwargs],
+    ) -> HookContext:
+        """Dispatch before-* lifecycle events."""
+        return await self._dispatch_event(event, target=target, **kwargs)
+
     async def notify_before_connect(
         self,
         target: WebSocketResource,
@@ -208,12 +217,8 @@ class HookManager:
         params: dict[str, object],
     ) -> HookContext:
         """Fire ``before_connect`` hooks and return the shared context."""
-        return await self._dispatch_event(
-            "before_connect",
-            target=target,
-            req=req,
-            ws=ws,
-            params=params,
+        return await self._notify_before_event(
+            "before_connect", target, req=req, ws=ws, params=params
         )
 
     async def notify_after_connect(self, context: HookContext) -> None:
@@ -233,12 +238,7 @@ class HookManager:
         raw: str | bytes,
     ) -> HookContext:
         """Run ``before_receive`` hooks and return the shared context."""
-        return await self._dispatch_event(
-            "before_receive",
-            target=target,
-            ws=ws,
-            raw=raw,
-        )
+        return await self._notify_before_event("before_receive", target, ws=ws, raw=raw)
 
     async def notify_after_receive(self, context: HookContext) -> None:
         """Run ``after_receive`` hooks using ``context``."""
@@ -257,9 +257,6 @@ class HookManager:
         close_code: int,
     ) -> HookContext:
         """Run ``before_disconnect`` hooks and return the shared context."""
-        return await self._dispatch_event(
-            "before_disconnect",
-            target=target,
-            ws=ws,
-            close_code=close_code,
+        return await self._notify_before_event(
+            "before_disconnect", target, ws=ws, close_code=close_code
         )

--- a/falcon_pachinko/resource.py
+++ b/falcon_pachinko/resource.py
@@ -25,6 +25,7 @@ if typ.TYPE_CHECKING:  # pragma: no cover - imported for type hints
 
 from .dispatcher import dispatch
 from .handlers import Handler, HandlerInfo, _HandlesMessageDescriptor
+from .hooks import HookCollection, HookManager
 from .schema import populate_struct_handlers, validate_schema_types
 
 
@@ -41,6 +42,7 @@ class WebSocketResource:
     handlers: typ.ClassVar[dict[str, HandlerInfo]]
     _struct_handlers: typ.ClassVar[dict[type, HandlerInfo]] = {}
     schema: type | None = None
+    hooks: HookCollection = HookCollection()
 
     def add_subroute(
         self,
@@ -115,6 +117,11 @@ class WebSocketResource:
         cls._apply_overrides(handlers)
         cls.handlers = handlers
         cls._init_schema_registry()
+        parent_hooks = getattr(cls, "hooks", None)
+        if isinstance(parent_hooks, HookCollection):
+            cls.hooks = HookCollection.inherit(parent_hooks)
+        else:
+            cls.hooks = HookCollection()
 
     @classmethod
     def _collect_base_handlers(cls) -> dict[str, HandlerInfo]:
@@ -213,4 +220,15 @@ class WebSocketResource:
 
     async def dispatch(self, ws: WebSocketLike, raw: str | bytes) -> None:
         """Decode ``raw`` and route it to the appropriate handler."""
-        await dispatch(self, ws, raw)
+        manager = getattr(self, "_hook_manager", None)
+        if manager is None:
+            manager = HookManager(global_hooks=HookCollection(), resources=(self,))
+            self._hook_manager = manager  # type: ignore[attr-defined]
+        context = await manager.notify_before_receive(self, ws=ws, raw=raw)
+        try:
+            await dispatch(self, ws, raw)
+        except Exception as exc:
+            context.error = exc
+            await manager.notify_after_receive(context)
+            raise
+        await manager.notify_after_receive(context)

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -17,6 +17,8 @@ import typing as typ
 
 import falcon
 
+from .hooks import HookCollection, HookContext, HookManager
+
 if typ.TYPE_CHECKING:
     from .protocols import WebSocketLike
     from .resource import WebSocketResource
@@ -95,6 +97,7 @@ class WebSocketRouter:
         self._mount_prefix: str = ""
         self._mount_lock = threading.Lock()
         self._names: dict[str, str] = {}
+        self.global_hooks = HookCollection()
         self.name = name
 
     def _compile_and_store_route(
@@ -150,18 +153,9 @@ class WebSocketRouter:
         if kwargs is None:
             kwargs = {}
 
-        if not callable(resource):
-            msg = "resource must be callable"
-            raise TypeError(msg)
-
-        path = _normalize_path(path)
-        canonical = _canonical_path(path)
-        if any(r.canonical == canonical for r in self._raw):
-            msg = f"route path {path!r} already registered"
-            raise ValueError(msg)
-        if name and name in self._names:
-            msg = f"route name {name!r} already registered"
-            raise ValueError(msg)
+        self._validate_resource_type(resource)
+        path, canonical = self._normalize_route_path(path)
+        self._check_route_conflicts(canonical, name, path)
 
         # Compile once to validate the template. The prefix is applied lazily
         # upon the first request since it may not yet be known at this point.
@@ -175,6 +169,32 @@ class WebSocketRouter:
                 self._compile_and_store_route(canonical, factory)
         if name:
             self._names[name] = path
+
+    def _validate_resource_type(
+        self, resource: type[WebSocketResource] | typ.Callable[..., WebSocketResource]
+    ) -> None:
+        """Ensure ``resource`` can be called to create a handler."""
+        if not callable(resource):
+            msg = "resource must be callable"
+            raise TypeError(msg)
+
+    def _normalize_route_path(self, path: str) -> tuple[str, str]:
+        """Return normalized and canonical variants of ``path``."""
+        normalized = _normalize_path(path)
+        canonical = _canonical_path(normalized)
+        return normalized, canonical
+
+    def _check_route_conflicts(
+        self, canonical: str, name: str | None, path: str | None = None
+    ) -> None:
+        """Raise if ``canonical`` or ``name`` already exists."""
+        display_path = path if path is not None else canonical
+        if any(r.canonical == canonical for r in self._raw):
+            msg = f"route path {display_path!r} already registered"
+            raise ValueError(msg)
+        if name and name in self._names:
+            msg = f"route name {name!r} already registered"
+            raise ValueError(msg)
 
     def url_for(self, name: str, **params: object) -> str:
         """Return the URL path associated with ``name`` formatted with ``params``."""
@@ -237,21 +257,67 @@ class WebSocketRouter:
         if result is None:
             return False
         params, remaining = result
+        return await self._execute_route_with_error_handling(
+            route, req, ws, params, remaining
+        )
 
+    async def _execute_route_with_error_handling(
+        self,
+        route: _CompiledRoute,
+        req: falcon.Request,
+        ws: WebSocketLike,
+        params: dict[str, str],
+        remaining: str,
+    ) -> bool:
+        """Run the routing pipeline and close ``ws`` on unexpected errors."""
         try:
-            base_resource = route.factory()
-            resolution = self._resolve_resource_and_path(
-                base_resource, remaining, params
+            return await self._process_route_resolution(
+                route, req, ws, params, remaining
             )
-            if resolution is None:
-                return False
-            resource, remaining, params = resolution
-            if resource is base_resource and not route.pattern.fullmatch(req.path):
-                return False
-            return await self._handle_websocket_connection(resource, req, ws, params)
         except Exception:
             await ws.close()
             raise
+
+    async def _process_route_resolution(
+        self,
+        route: _CompiledRoute,
+        req: falcon.Request,
+        ws: WebSocketLike,
+        params: dict[str, str],
+        remaining: str,
+    ) -> bool:
+        """Resolve the final resource and dispatch the connection."""
+        base_resource = route.factory()
+        chain = [base_resource]
+        resolution = self._resolve_resource_and_path(
+            base_resource, remaining, params, chain
+        )
+        if resolution is None:
+            return False
+        resource, _, params, chain = resolution
+        if not self._validate_final_resource(resource, base_resource, route, req):
+            return False
+        manager = self._setup_hook_management(chain)
+        return await self._handle_websocket_connection(
+            resource, req, ws, params, hook_manager=manager
+        )
+
+    def _validate_final_resource(
+        self,
+        resource: WebSocketResource,
+        base_resource: WebSocketResource,
+        route: _CompiledRoute,
+        req: falcon.Request,
+    ) -> bool:
+        """Return ``True`` if ``resource`` is usable for ``req``."""
+        return not (resource is base_resource and not route.pattern.fullmatch(req.path))
+
+    def _setup_hook_management(self, chain: list[WebSocketResource]) -> HookManager:
+        """Attach a :class:`HookManager` to every resource in ``chain``."""
+        manager = HookManager(global_hooks=self.global_hooks, resources=chain)
+        for item in chain:
+            item._hook_manager = manager  # type: ignore[attr-defined]
+        return manager
 
     def _normalize_path_remaining(
         self, remaining: str, match: re.Match[str]
@@ -285,6 +351,7 @@ class WebSocketRouter:
         resource: WebSocketResource,
         path: str,
         params: dict[str, str],
+        chain: list[WebSocketResource],
     ) -> tuple[WebSocketResource, str, dict[str, str]]:
         """Traverse ``resource`` subroutes matching ``path``."""
         while path not in ("", "/"):
@@ -293,6 +360,7 @@ class WebSocketRouter:
                 break
             resource, path, new_params = result
             params |= new_params
+            chain.append(resource)
 
         return resource, path, params
 
@@ -315,12 +383,13 @@ class WebSocketRouter:
         resource: WebSocketResource,
         remaining: str,
         params: dict[str, str],
-    ) -> tuple[WebSocketResource, str, dict[str, str]] | None:
-        """Return resolved resource and path or ``None`` if invalid."""
+        chain: list[WebSocketResource],
+    ) -> tuple[WebSocketResource, str, dict[str, str], list[WebSocketResource]] | None:
+        """Return resolved resource, params, and traversal chain."""
         resolved, remaining, params = self._resolve_subroutes(
-            resource, remaining, params
+            resource, remaining, params, chain
         )
-        return None if remaining not in ("", "/") else (resolved, remaining, params)
+        return (resolved, remaining, params, chain) if remaining in ("", "/") else None
 
     async def _handle_websocket_connection(
         self,
@@ -328,9 +397,72 @@ class WebSocketRouter:
         req: falcon.Request,
         ws: WebSocketLike,
         params: dict[str, str],
+        *,
+        hook_manager: HookManager,
     ) -> bool:
         """Accept or close ``ws`` based on ``resource`` decision."""
-        should_accept = await resource.on_connect(req, ws, **params)
+        context, params_for_handler = await self._prepare_connection_context(
+            hook_manager, resource, req, ws, params
+        )
+        should_accept = await self._execute_resource_handler(
+            resource, req, ws, params_for_handler, context, hook_manager
+        )
+        context.params = params_for_handler
+        return await self._finalize_connection(
+            ws,
+            should_accept=should_accept,
+            context=context,
+            hook_manager=hook_manager,
+        )
+
+    async def _prepare_connection_context(
+        self,
+        hook_manager: HookManager,
+        resource: WebSocketResource,
+        req: falcon.Request,
+        ws: WebSocketLike,
+        params: dict[str, str],
+    ) -> tuple[HookContext, dict[str, object]]:
+        """Return the hook context and handler parameters."""
+        params_obj: dict[str, object] = dict(params)
+        context = await hook_manager.notify_before_connect(
+            resource, req=req, ws=ws, params=params_obj
+        )
+        params_for_handler = (
+            context.params if context.params is not None else params_obj
+        )
+        return context, params_for_handler
+
+    async def _execute_resource_handler(
+        self,
+        resource: WebSocketResource,
+        req: falcon.Request,
+        ws: WebSocketLike,
+        params: dict[str, object],
+        context: HookContext,
+        hook_manager: HookManager,
+    ) -> bool:
+        """Invoke ``resource.on_connect`` handling hook error propagation."""
+        try:
+            return await resource.on_connect(req, ws, **params)
+        except Exception as exc:
+            context.error = exc
+            context.result = False
+            context.params = params
+            await hook_manager.notify_after_connect(context)
+            raise
+
+    async def _finalize_connection(
+        self,
+        ws: WebSocketLike,
+        *,
+        should_accept: bool,
+        context: HookContext,
+        hook_manager: HookManager,
+    ) -> bool:
+        """Complete the connection lifecycle and honour ``should_accept``."""
+        context.result = bool(should_accept)
+        await hook_manager.notify_after_connect(context)
         if not should_accept:
             await ws.close()
             return True

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -469,7 +469,7 @@ class WebSocketRouter:
         hook_manager: HookManager,
     ) -> bool:
         """Complete the connection lifecycle and honour ``should_accept``."""
-        context.result = bool(should_accept)
+        context.result = should_accept
         await hook_manager.notify_after_connect(context)
         if not should_accept:
             await ws.close()

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -303,7 +303,7 @@ class WebSocketRouter:
         """Attach a :class:`HookManager` to every resource in ``chain``."""
         manager = HookManager(global_hooks=self.global_hooks, resources=chain)
         for item in chain:
-            item._hook_manager = manager  # type: ignore[attr-defined]
+            item.bind_hook_manager(manager)
         return manager
 
     def _normalize_path_remaining(

--- a/falcon_pachinko/unittests/helpers.py
+++ b/falcon_pachinko/unittests/helpers.py
@@ -2,6 +2,19 @@
 
 from __future__ import annotations
 
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from falcon_pachinko import HookManager, WebSocketResource
+else:  # pragma: no cover - runtime placeholders for type hints
+    HookManager = typ.Any  # type: ignore[assignment]
+    WebSocketResource = typ.Any  # type: ignore[assignment]
+
+
+def bind_default_hooks(resource: WebSocketResource) -> HookManager:
+    """Bind a standalone hook manager for ``resource`` during tests."""
+    return resource.bind_default_hook_manager()
+
 
 class DummyWS:
     """A dummy WebSocket implementation for testing purposes."""

--- a/falcon_pachinko/unittests/test_handles_message.py
+++ b/falcon_pachinko/unittests/test_handles_message.py
@@ -26,7 +26,7 @@ from falcon_pachinko.exceptions import (
     DuplicateHandlerRegistrationError,
     HandlerSignatureError,
 )
-from falcon_pachinko.unittests.helpers import DummyWS
+from falcon_pachinko.unittests.helpers import DummyWS, bind_default_hooks
 
 
 class PingPayload(ms.Struct):
@@ -66,6 +66,7 @@ async def test_decorator_registers_handler() -> None:
     3. The payload is properly deserialized and passed to the handler
     """
     r = DecoratedResource()
+    bind_default_hooks(r)
     raw = msjson.encode({"type": "ping", "payload": {"text": "hi"}})
     await r.dispatch(DummyWS(), raw)
     assert r.seen == ["hi"]
@@ -206,6 +207,7 @@ async def test_handlers_inherited() -> None:
     4. Method overrides without decoration still work as handlers
     """
     r = ChildResource()
+    bind_default_hooks(r)
     await r.dispatch(DummyWS(), msjson.encode({"type": "parent"}))
     await r.dispatch(DummyWS(), msjson.encode({"type": "child"}))
     assert r.invoked == ["parent", "child"]
@@ -220,6 +222,7 @@ async def test_decorated_override() -> None:
     precedence over the parent's handler.
     """
     r = DecoratedOverride()
+    bind_default_hooks(r)
     await r.dispatch(DummyWS(), msjson.encode({"type": "parent"}))
     assert r.invoked == "decorated"
 

--- a/falcon_pachinko/unittests/test_hooks.py
+++ b/falcon_pachinko/unittests/test_hooks.py
@@ -1,0 +1,326 @@
+"""Unit tests covering the hook manager orchestration."""
+
+from __future__ import annotations
+
+import typing as typ
+
+import pytest
+
+from falcon_pachinko import (
+    HookCollection,
+    HookContext,
+    WebSocketResource,
+    WebSocketRouter,
+)
+from falcon_pachinko.unittests.helpers import DummyWS
+
+
+def dummy_hook(context: HookContext) -> None:
+    """No-op hook used for validation tests."""
+    _ = context
+
+
+class HookChild(WebSocketResource):
+    """Child resource used to validate hook orchestration."""
+
+    instances: typ.ClassVar[list[HookChild]] = []
+    _events: typ.ClassVar[list[str]] = []
+
+    def __init__(self) -> None:
+        HookChild.instances.append(self)
+        self.params: dict[str, object] = {}
+
+    async def on_connect(self, req: object, ws: object, **params: object) -> bool:
+        """Capture connection parameters for later assertions."""
+        self.params = params
+        return True
+
+    async def on_unhandled(self, ws: object, message: str | bytes) -> None:
+        """Record handler invocation for ordering validation."""
+        self._events.append("handler.child")
+
+
+class HookParent(WebSocketResource):
+    """Parent resource that mounts ``HookChild``."""
+
+    instances: typ.ClassVar[list[HookParent]] = []
+
+    def __init__(self) -> None:
+        HookParent.instances.append(self)
+        self.add_subroute("child", HookChild)
+
+
+def create_global_hook(
+    events: list[str],
+) -> typ.Callable[[HookContext], typ.Awaitable[None]]:
+    """Produce a global hook that records context assertions."""
+
+    async def global_hook(context: HookContext) -> None:
+        assert isinstance(context.target, HookChild)
+        if context.event == "before_connect":
+            if context.params is None:
+                context.params = {}
+            context.params.setdefault("global", True)
+        elif context.event == "after_connect":
+            assert context.result is True
+        elif context.event == "after_receive":
+            assert context.error is None
+        events.append(f"global.{context.event}")
+
+    return global_hook
+
+
+def create_parent_hook(
+    events: list[str],
+) -> typ.Callable[[HookContext], typ.Awaitable[None]]:
+    """Produce a parent-level hook for order verification."""
+
+    async def parent_hook(context: HookContext) -> None:
+        assert context.resource in HookParent.instances
+        if context.event == "before_connect":
+            if context.params is None:
+                context.params = {}
+            context.params.setdefault("parent", True)
+        elif context.event == "after_receive":
+            assert context.error is None
+        events.append(f"parent.{context.event}")
+
+    return parent_hook
+
+
+def create_child_hook(
+    events: list[str],
+) -> typ.Callable[[HookContext], typ.Awaitable[None]]:
+    """Produce a child-level hook that inspects payload flow."""
+
+    async def child_hook(context: HookContext) -> None:
+        assert isinstance(context.target, HookChild)
+        if context.event == "after_connect":
+            assert context.result is True
+        elif context.event == "before_receive":
+            assert context.raw == b'{"type":"noop"}'
+        elif context.event == "after_receive":
+            assert context.error is None
+        events.append(f"child.{context.event}")
+
+    return child_hook
+
+
+class HookTestEnvironment:
+    """Encapsulate router, hooks, and connection state for tests."""
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        HookChild._events = self.events
+        HookChild.instances = []
+        HookParent.instances = []
+        self.router = WebSocketRouter()
+        self._ws: DummyWS | None = None
+        self._register_hooks()
+
+    def _register_hooks(self) -> None:
+        global_hook = create_global_hook(self.events)
+        parent_hook = create_parent_hook(self.events)
+        child_hook = create_child_hook(self.events)
+
+        self.router.global_hooks.add("before_connect", global_hook)
+        self.router.global_hooks.add("after_connect", global_hook)
+        self.router.global_hooks.add("before_receive", global_hook)
+        self.router.global_hooks.add("after_receive", global_hook)
+
+        HookParent.hooks.add("before_connect", parent_hook)
+        HookParent.hooks.add("after_connect", parent_hook)
+        HookParent.hooks.add("before_receive", parent_hook)
+        HookParent.hooks.add("after_receive", parent_hook)
+
+        HookChild.hooks.add("before_connect", child_hook)
+        HookChild.hooks.add("after_connect", child_hook)
+        HookChild.hooks.add("before_receive", child_hook)
+        HookChild.hooks.add("after_receive", child_hook)
+
+        self.router.add_route("/hooks", HookParent)
+        self.router.mount("/")
+
+    async def open_connection(self) -> HookChild:
+        """Create a connection and return the instantiated child resource."""
+        self._ws = DummyWS()
+        req = type("Req", (), {"path": "/hooks/child", "path_template": ""})()
+        await self.router.on_websocket(req, self._ws)
+        return HookChild.instances[-1]
+
+    async def dispatch_noop(self, child: HookChild) -> None:
+        """Send a no-op payload through the active connection."""
+        assert self._ws is not None, (
+            "call open_connection() before dispatching messages"
+        )
+        await child.dispatch(self._ws, b'{"type":"noop"}')
+
+
+@pytest.fixture(autouse=True)
+def reset_hook_state() -> typ.Iterator[None]:
+    """Ensure per-test isolation for hook registries and instances."""
+    HookParent.hooks = HookCollection()
+    HookChild.hooks = HookCollection()
+    HookParent.instances = []
+    HookChild.instances = []
+    HookChild._events = []
+    yield
+    HookParent.hooks = HookCollection()
+    HookChild.hooks = HookCollection()
+    HookParent.instances = []
+    HookChild.instances = []
+    HookChild._events = []
+
+
+@pytest.fixture
+def hook_test_environment() -> HookTestEnvironment:
+    """Provide a configured hook scenario for tests."""
+    return HookTestEnvironment()
+
+
+@pytest.mark.asyncio
+async def test_hooks_execute_in_layered_order(
+    hook_test_environment: HookTestEnvironment,
+) -> None:
+    """Hooks fire in onion order across global, parent, and child scopes."""
+    child = await hook_test_environment.open_connection()
+    await hook_test_environment.dispatch_noop(child)
+
+    assert hook_test_environment.events == [
+        "global.before_connect",
+        "parent.before_connect",
+        "child.before_connect",
+        "child.after_connect",
+        "parent.after_connect",
+        "global.after_connect",
+        "global.before_receive",
+        "parent.before_receive",
+        "child.before_receive",
+        "handler.child",
+        "child.after_receive",
+        "parent.after_receive",
+        "global.after_receive",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hook_context_parameter_propagation(
+    hook_test_environment: HookTestEnvironment,
+) -> None:
+    """Before-connect hooks may amend params passed to the resource."""
+    child = await hook_test_environment.open_connection()
+
+    assert child.params["global"] is True
+    assert child.params["parent"] is True
+
+
+@pytest.mark.asyncio
+async def test_message_processing_hooks_capture_handler_events(
+    hook_test_environment: HookTestEnvironment,
+) -> None:
+    """Receive hooks surround dispatch and observe handler execution."""
+    child = await hook_test_environment.open_connection()
+    await hook_test_environment.dispatch_noop(child)
+
+    assert hook_test_environment.events[6:] == [
+        "global.before_receive",
+        "parent.before_receive",
+        "child.before_receive",
+        "handler.child",
+        "child.after_receive",
+        "parent.after_receive",
+        "global.after_receive",
+    ]
+
+
+def test_hookcollection_add_unsupported_event() -> None:
+    """Registering an unknown event raises ``ValueError``."""
+    collection = HookCollection()
+    with pytest.raises(ValueError, match="Unsupported hook event"):
+        collection.add("unsupported_event", dummy_hook)
+
+
+def test_hookcollection_add_non_callable() -> None:
+    """Registering a non-callable hook raises ``TypeError``."""
+    collection = HookCollection()
+    with pytest.raises(TypeError, match="hook must be callable"):
+        collection.add("before_connect", "not_a_callable")
+
+
+def test_hookcollection_inheritance_propagates_changes() -> None:
+    """Child classes observe parent hook registrations added later."""
+
+    class Parent(WebSocketResource):
+        pass
+
+    class Child(Parent):
+        pass
+
+    def parent_before(context: HookContext) -> None:
+        return None
+
+    def child_after(context: HookContext) -> None:
+        return None
+
+    Parent.hooks.add("before_receive", parent_before)
+    assert parent_before in Parent.hooks.iter("before_receive")
+    assert parent_before in Child.hooks.iter("before_receive")
+
+    Child.hooks.add("after_receive", child_after)
+    assert child_after in Child.hooks.iter("after_receive")
+    assert child_after not in Parent.hooks.iter("after_receive")
+
+
+@pytest.mark.asyncio
+async def test_after_receive_reports_errors() -> None:
+    """After hooks receive the raised exception."""
+    events: list[tuple[str, str]] = []
+
+    class BoomResource(WebSocketResource):
+        instances: typ.ClassVar[list[BoomResource]] = []
+
+        def __init__(self) -> None:
+            BoomResource.instances.append(self)
+
+        async def on_connect(self, req: object, ws: object, **params: object) -> bool:
+            return True
+
+        async def on_boom(self, ws: object, payload: object) -> None:
+            raise RuntimeError("boom")
+
+    async def global_hook(context: HookContext) -> None:
+        events.append(("global", context.event))
+        if context.event == "after_receive":
+            assert isinstance(context.error, RuntimeError)
+
+    async def resource_hook(context: HookContext) -> None:
+        events.append(("resource", context.event))
+        if context.event == "before_receive":
+            assert context.raw == b'{"type":"boom"}'
+        if context.event == "after_receive":
+            assert isinstance(context.error, RuntimeError)
+
+    router = WebSocketRouter()
+    router.global_hooks.add("before_receive", global_hook)
+    router.global_hooks.add("after_receive", global_hook)
+
+    BoomResource.hooks.add("before_receive", resource_hook)
+    BoomResource.hooks.add("after_receive", resource_hook)
+
+    router.add_route("/boom", BoomResource)
+    router.mount("/")
+
+    ws = DummyWS()
+    req = type("Req", (), {"path": "/boom", "path_template": ""})()
+    await router.on_websocket(req, ws)
+
+    resource = BoomResource.instances[-1]
+    with pytest.raises(RuntimeError):
+        await resource.dispatch(ws, b'{"type":"boom"}')
+
+    assert events == [
+        ("global", "before_receive"),
+        ("resource", "before_receive"),
+        ("resource", "after_receive"),
+        ("global", "after_receive"),
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "falcon-pachinko"
 version = "0.1.0-alpha2"
 description = "falcon-pachinko package"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = { text = "ISC" }
 dependencies = ["msgspec>=0.18,<1", "falcon>=4,<5"]
 authors = [{ name = "Payton McIntosh", email = "pmcintosh@df12.net" }]
@@ -13,8 +13,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: ISC License (ISCL)",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Topic :: Internet :: WWW/HTTP",
@@ -30,7 +28,7 @@ dev = ["pytest", "pytest-asyncio", "pytest-bdd", "ruff", "pyright[nodejs]"]
 examples = ["aiosqlite", "uvicorn", "websocket-client"]
 
 [tool.pyright]
-pythonVersion = "3.10"
+pythonVersion = "3.12"
 typeCheckingMode = "strict"
 include = ["falcon_pachinko"]
 


### PR DESCRIPTION
## Summary
- add reusable hook child/parent classes and hook factory helpers to share context assertions
- provide a test environment fixture that resets hook state per run and drives connection setup
- split the hook order test into focused async cases for layered sequencing, parameter propagation, and receive handling

## Testing
- make fmt
- make lint
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68c990bb92988322b5b52947b6394f0b

## Summary by Sourcery

Introduce a structured hook framework and refactor routing to support onion-style lifecycle hooks on WebSocket connections and messages

New Features:
- Implement a multi-tier hook system with global and per-resource lifecycle hooks
- Integrate HookManager and HookContext into WebSocketRouter and WebSocketResource pipelines

Enhancements:
- Refactor WebSocketRouter to modularize route validation, normalization, conflict checking, and processing
- Introduce helper methods to separate connection handling, routing resolution, and error management
- Export HookCollection, HookContext, and HookManager in package API

Documentation:
- Mark the multi-tiered hook system tasks as completed in the roadmap

Tests:
- Add comprehensive unit tests for hook registration, ordering, parameter propagation, and error handling
- Add behavioural tests with pytest-bdd to verify hook execution order and error propagation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Multi‑tier hook system for WebSocket lifecycles (before/after connect, receive, disconnect) with layered (onion‑style) ordering, error propagation, per‑resource inheritance, router‑level global hooks, and public exports for hook types.

- **Documentation**
  - Roadmap updated to mark the hook‑system phase complete.

- **Tests**
  - Added comprehensive unit and BDD tests covering ordering, parameter propagation, error handling, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->