### PR TITLE
Build full reference example with tests

### DIFF
--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -788,7 +788,7 @@ async def lifespan(app_instance):
 A JavaScript client would interact as follows:
 
 1. **Connect**:
-   `const socket = new WebSocket("ws://localhost:8000/ws/chat/general");`
+  `const socket = new WebSocket("wss://example.com/ws/chat/general");`
 
 2. **Send Messages**:
 
@@ -1038,7 +1038,7 @@ class ProjectResource(WebSocketResource):
 # This assumes a router is already defined.
 router.add_route('/projects/{project_id}', ProjectResource)
 
-# A connection to "ws://.../projects/123/tasks" would be handled
+# A connection to "wss://.../projects/123/tasks" would be handled
 # by an instance of TasksResource, with the context of project "123".
 
 ```
@@ -1570,7 +1570,7 @@ already provides a reliable asyncio client with excellent RFC coverage.
 
   ```python
   async with WebSocketTestClient(
-      "ws://localhost:8000", allow_insecure=True
+      "wss://example.com", allow_insecure=True
   ).connect("/ws/chat") as session:
       await session.send_json({"type": "ping"})
       reply = await session.receive_json()

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -1418,6 +1418,15 @@ classDiagram
     ServiceContainer --> StatusResource : provides dependencies
     StatusEndpoint --> ServiceContainer : resolves 'db'
     StatusResource --> WebSocketConnectionManager
+
+The comprehensive reference application under ``examples/reference_app`` builds
+on this pattern to exercise every advanced feature in one place. Its router is
+mounted at ``/ws`` and instantiates ``WorkspaceResource`` → ``ProjectResource`` →
+``TaskStreamResource`` chains through the shared `ServiceContainer`, allowing
+hooks to seed per-connection state while message handlers rely on schema-driven
+dispatch. The same container also wires the announcement worker and HTTP
+helpers, providing a concrete illustration of the stateful,
+per-connection resources described in §5.5.1.
     StatusResource --> aiosqlite.Connection
 ```
 
@@ -1547,8 +1556,8 @@ already provides a reliable asyncio client with excellent RFC coverage.
 
 - **Instantiation**: `WebSocketTestClient(app_url: str, *, headers: dict | None,
   subprotocols: list[str] | None, allow_insecure: bool =
-  False)` stores the base URL and defaults, requiring opt-in for local `ws://`
-  use.
+  False)` stores the base URL and defaults, requiring opt-in for local `ws://
+  ` use.
 
 - **Connection Context**: `async with client.connect(path)` opens a connection
   with

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -1418,6 +1418,8 @@ classDiagram
     ServiceContainer --> StatusResource : provides dependencies
     StatusEndpoint --> ServiceContainer : resolves 'db'
     StatusResource --> WebSocketConnectionManager
+    StatusResource --> aiosqlite.Connection
+```
 
 The comprehensive reference application under ``examples/reference_app`` builds
 on this pattern to exercise every advanced feature in one place. Its router is
@@ -1427,8 +1429,6 @@ hooks to seed per-connection state while message handlers rely on schema-driven
 dispatch. The same container also wires the announcement worker and HTTP
 helpers, providing a concrete illustration of the stateful,
 per-connection resources described in §5.5.1.
-    StatusResource --> aiosqlite.Connection
-```
 
 ##### Usage Patterns
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -206,12 +206,12 @@ the library is ready for use.
     ASGI app, handles connection lifecycle management, and exposes helpers for
     pushing and inspecting messages.
 
-- [ ] **Build a Full Reference Example.**
+- [x] **Build a Full Reference Example.**
 
-  - [ ] Create a new, comprehensive example application that demonstrates all
-    the advanced features working in concert: a mountable router, schema-driven
-    dispatch, nested resources, lifespan workers, hooks, and dependency
-    injection.
+  - [x] Create the `examples/reference_app` project showcasing router mounting,
+    schema-driven dispatch, nested resources, hooks, dependency injection, and
+    lifespan-managed workers end-to-end, backed by pytest unit tests and
+    pytest-bdd behavioural coverage.
 
 - [ ] **Rewrite the Documentation.**
 

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,5 @@
+"""Example applications demonstrating Falcon-Pachinko features."""
+
+from __future__ import annotations
+
+__all__ = ["reference_app"]

--- a/examples/reference_app/__init__.py
+++ b/examples/reference_app/__init__.py
@@ -1,0 +1,7 @@
+"""Full reference application demonstrating the advanced feature set."""
+
+from __future__ import annotations
+
+from .server import build_container, build_router, create_app
+
+__all__ = ["build_container", "build_router", "create_app"]

--- a/examples/reference_app/resources.py
+++ b/examples/reference_app/resources.py
@@ -104,6 +104,15 @@ class ProjectResource(WebSocketResource):
         self.add_subroute("tasks", TaskStreamResource)
 
 
+@dc.dataclass(frozen=True, slots=True)
+class TaskOperationConfig:
+    """Configuration for a task operation handler."""
+
+    repo_operation: typ.Callable[..., Task]
+    response_type: str
+    payload_builder: typ.Callable[[Task], dict[str, object]]
+
+
 class TaskStreamResource(WebSocketResource):
     """Final resource that handles the bidirectional task stream."""
 
@@ -212,9 +221,14 @@ class TaskStreamResource(WebSocketResource):
         await self._execute_task_operation(
             ws,
             payload.task_id,
-            self._repo.complete_task,
-            "task.completed",
-            lambda task: {"task_id": task.task_id, "completed": task.completed},
+            TaskOperationConfig(
+                repo_operation=self._repo.complete_task,
+                response_type="task.completed",
+                payload_builder=lambda task: {
+                    "task_id": task.task_id,
+                    "completed": task.completed,
+                },
+            ),
         )
 
     @handles_message("task.assign")
@@ -223,9 +237,14 @@ class TaskStreamResource(WebSocketResource):
         await self._execute_task_operation(
             ws,
             payload.task_id,
-            self._repo.assign_task,
-            "task.assigned",
-            lambda task: {"task_id": task.task_id, "assignee": task.assigned_to},
+            TaskOperationConfig(
+                repo_operation=self._repo.assign_task,
+                response_type="task.assigned",
+                payload_builder=lambda task: {
+                    "task_id": task.task_id,
+                    "assignee": task.assigned_to,
+                },
+            ),
             payload.assignee,
         )
 
@@ -275,14 +294,14 @@ class TaskStreamResource(WebSocketResource):
         self,
         ws: WebSocketLike,
         task_id: str,
-        repo_operation: typ.Callable[..., Task],
-        response_type: str,
-        payload_builder: typ.Callable[[Task], dict[str, object]],
+        config: TaskOperationConfig,
         *operation_args: object,
     ) -> None:
+        """Execute a task operation and send the standardized response."""
+
         workspace_id = typ.cast("str", self.state["workspace_id"])
         project_id = typ.cast("str", self.state["project_id"])
-        task = await repo_operation(
+        task = await config.repo_operation(
             workspace_id,
             project_id,
             task_id,
@@ -290,8 +309,8 @@ class TaskStreamResource(WebSocketResource):
         )
         await ws.send_media(
             {
-                "type": response_type,
-                "payload": payload_builder(task),
+                "type": config.response_type,
+                "payload": config.payload_builder(task),
             }
         )
 

--- a/examples/reference_app/resources.py
+++ b/examples/reference_app/resources.py
@@ -1,0 +1,341 @@
+"""WebSocket resources powering the reference application example."""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import secrets
+import typing as typ
+
+import msgspec as ms
+
+from falcon_pachinko import (
+    WebSocketConnectionManager,
+    WebSocketLike,
+    WebSocketResource,
+    handles_message,
+)
+from falcon_pachinko.hooks import HookContext, HookEvent
+
+if typ.TYPE_CHECKING:  # pragma: no cover - typing helpers
+    import falcon
+
+    from .services import AnnouncementFeed, AuditTrail, WorkspaceRepository
+
+__all__ = [
+    "AddTask",
+    "AssignTask",
+    "BroadcastNote",
+    "CompleteTask",
+    "ListTasks",
+    "ProjectResource",
+    "TaskStreamResource",
+    "WorkspaceResource",
+    "register_reference_hooks",
+]
+
+
+class AddTask(ms.Struct, tag="task.add"):
+    """Message that creates a new task inside the active project."""
+
+    task_id: str
+    title: str
+    assignee: str | None = None
+
+
+class CompleteTask(ms.Struct, tag="task.complete"):
+    """Message that marks an existing task as completed."""
+
+    task_id: str
+
+
+class AssignTask(ms.Struct, tag="task.assign"):
+    """Message that reassigns a task to a different collaborator."""
+
+    task_id: str
+    assignee: str
+
+
+class ListTasks(ms.Struct, tag="task.list"):
+    """Message requesting the current task list snapshot."""
+
+    include_completed: bool = True
+
+
+class BroadcastNote(ms.Struct, tag="session.note"):
+    """Session-scoped annotation broadcast to all workspace members."""
+
+    text: str
+
+
+TaskSchema = AddTask | CompleteTask | AssignTask | ListTasks | BroadcastNote
+
+
+def _workspace_room(workspace_id: str) -> str:
+    return f"workspace:{workspace_id}"
+
+
+class WorkspaceResource(WebSocketResource):
+    """Entry point for workspace-scoped routes."""
+
+    def __init__(
+        self,
+        *,
+        workspace_repo: WorkspaceRepository,
+        audit_trail: AuditTrail,
+    ) -> None:
+        self._repo = workspace_repo
+        self._audit = audit_trail
+        self.add_subroute("projects/{project_id}", ProjectResource)
+
+
+class ProjectResource(WebSocketResource):
+    """Intermediate resource responsible for project validation."""
+
+    def __init__(
+        self,
+        *,
+        workspace_repo: WorkspaceRepository,
+        audit_trail: AuditTrail,
+    ) -> None:
+        self._repo = workspace_repo
+        self._audit = audit_trail
+        self.add_subroute("tasks", TaskStreamResource)
+
+
+class TaskStreamResource(WebSocketResource):
+    """Final resource that handles the bidirectional task stream."""
+
+    schema = TaskSchema
+
+    def __init__(
+        self,
+        *,
+        workspace_repo: WorkspaceRepository,
+        audit_trail: AuditTrail,
+        announcement_feed: AnnouncementFeed,
+        conn_mgr: WebSocketConnectionManager,
+    ) -> None:
+        self._repo = workspace_repo
+        self._audit = audit_trail
+        self._feed = announcement_feed
+        self._conn_mgr = conn_mgr
+        self._conn_id: str | None = None
+
+    async def on_connect(
+        self,
+        req: "falcon.Request",  # noqa: UP037
+        ws: WebSocketLike,
+        *,
+        workspace_id: str,
+        project_id: str,
+        user: str | None = None,
+    ) -> bool:
+        """Attach the websocket to the workspace-wide room."""
+        conn_id = secrets.token_hex(12)
+        await self._conn_mgr.add_connection(conn_id, ws)
+        await self._conn_mgr.join_room(conn_id, _workspace_room(workspace_id))
+        self._conn_id = conn_id
+        self.state.setdefault("workspace_id", workspace_id)
+        self.state["project_id"] = project_id
+        self.state["user"] = user or req.get_header("x-user", default="guest")
+        await self._audit.record(
+            "session.open",
+            connection=conn_id,
+            workspace=workspace_id,
+            project=project_id,
+            user=self.state["user"],
+        )
+        await ws.send_media(
+            {
+                "type": "session.ready",
+                "payload": {
+                    "workspace": workspace_id,
+                    "project": project_id,
+                },
+            }
+        )
+        return True
+
+    async def on_disconnect(self, ws: WebSocketLike, close_code: int) -> None:
+        """Remove the websocket from the connection manager on disconnect."""
+        if self._conn_id is None:
+            return
+        await self._conn_mgr.remove_connection(self._conn_id)
+        await self._audit.record(
+            "session.closed",
+            connection=self._conn_id,
+            close_code=close_code,
+            workspace=self.state.get("workspace_id"),
+            project=self.state.get("project_id"),
+        )
+
+    @handles_message("task.add")
+    async def handle_add(self, ws: WebSocketLike, payload: AddTask) -> None:
+        """Create a task and broadcast a note for the workspace."""
+        workspace_id = typ.cast("str", self.state["workspace_id"])
+        project_id = typ.cast("str", self.state["project_id"])
+        await self._repo.add_task(
+            workspace_id,
+            project_id,
+            task_id=payload.task_id,
+            title=payload.title,
+            author=typ.cast("str", self.state.get("user", "guest")),
+            assignee=payload.assignee,
+        )
+        await ws.send_media(
+            {
+                "type": "task.added",
+                "payload": {
+                    "task_id": payload.task_id,
+                    "project_id": project_id,
+                },
+            }
+        )
+        await self._feed.publish(
+            workspace_id,
+            {
+                "type": "announcement",
+                "payload": {
+                    "kind": "task_added",
+                    "task_id": payload.task_id,
+                    "project_id": project_id,
+                },
+            },
+        )
+
+    @handles_message("task.complete")
+    async def handle_complete(self, ws: WebSocketLike, payload: CompleteTask) -> None:
+        """Mark a task as complete and acknowledge the caller."""
+        workspace_id = typ.cast("str", self.state["workspace_id"])
+        project_id = typ.cast("str", self.state["project_id"])
+        task = await self._repo.complete_task(workspace_id, project_id, payload.task_id)
+        await ws.send_media(
+            {
+                "type": "task.completed",
+                "payload": {
+                    "task_id": task.task_id,
+                    "completed": task.completed,
+                },
+            }
+        )
+
+    @handles_message("task.assign")
+    async def handle_assign(self, ws: WebSocketLike, payload: AssignTask) -> None:
+        """Reassign a task and echo the new owner."""
+        workspace_id = typ.cast("str", self.state["workspace_id"])
+        project_id = typ.cast("str", self.state["project_id"])
+        task = await self._repo.assign_task(
+            workspace_id, project_id, payload.task_id, payload.assignee
+        )
+        await ws.send_media(
+            {
+                "type": "task.assigned",
+                "payload": {
+                    "task_id": task.task_id,
+                    "assignee": task.assigned_to,
+                },
+            }
+        )
+
+    @handles_message("task.list", strict=False)
+    async def handle_list(self, ws: WebSocketLike, payload: ListTasks) -> None:
+        """Return the current task snapshot."""
+        workspace_id = typ.cast("str", self.state["workspace_id"])
+        project_id = typ.cast("str", self.state["project_id"])
+        tasks = await self._repo.list_tasks(
+            workspace_id,
+            project_id,
+            include_completed=payload.include_completed,
+        )
+        await ws.send_media(
+            {
+                "type": "task.list",
+                "payload": [dc.asdict(task) for task in tasks],
+            }
+        )
+
+    @handles_message("session.note")
+    async def handle_note(self, ws: WebSocketLike, payload: BroadcastNote) -> None:
+        """Publish a manual note to everyone in the workspace."""
+        workspace_id = typ.cast("str", self.state["workspace_id"])
+        await self._feed.publish(
+            workspace_id,
+            {
+                "type": "announcement",
+                "payload": {
+                    "kind": "note",
+                    "text": payload.text,
+                },
+            },
+        )
+        await ws.send_media({"type": "session.note", "payload": payload.text})
+
+    async def on_unhandled(self, ws: WebSocketLike, message: str | bytes) -> None:
+        """Send a helpful error response for unexpected payloads."""
+        await ws.send_media(
+            {
+                "type": "error",
+                "payload": "unsupported message",
+            }
+        )
+
+
+async def _seed_workspace(context: HookContext) -> None:
+    resource = typ.cast("WorkspaceResource", context.resource)
+    if not context.params:
+        return
+    workspace_id = typ.cast("str", context.params.get("workspace_id"))
+    workspace = await resource._repo.ensure_workspace(workspace_id)
+    resource.state["workspace_id"] = workspace_id
+    resource.state["workspace_name"] = workspace.name
+    await resource._audit.record("workspace.loaded", workspace=workspace_id)
+
+
+async def _seed_project(context: HookContext) -> None:
+    resource = typ.cast("ProjectResource", context.resource)
+    params = context.params or {}
+    workspace_id = typ.cast("str", params.get("workspace_id"))
+    project_id = typ.cast("str", params.get("project_id"))
+    project = await resource._repo.ensure_project(workspace_id, project_id)
+    resource.state["workspace_id"] = workspace_id
+    resource.state["project_id"] = project_id
+    resource.state["project_name"] = project.name
+    await resource._audit.record(
+        "project.loaded", workspace=workspace_id, project=project_id
+    )
+
+
+async def _record_receive(context: HookContext) -> None:
+    resource = typ.cast("TaskStreamResource", context.target)
+    if context.raw is None:
+        return
+    payload = context.raw
+    if isinstance(payload, bytes):
+        try:
+            payload = payload.decode("utf-8")
+        except UnicodeDecodeError:
+            payload = "<binary>"
+    await resource._audit.record("message.received", payload=payload)
+
+
+async def _record_receive_result(context: HookContext) -> None:
+    resource = typ.cast("TaskStreamResource", context.target)
+    await resource._audit.record("message.processed", result=context.result)
+
+
+_HOOKS_REGISTERED = False
+
+
+def register_reference_hooks() -> None:
+    """Attach lifecycle hooks used across the reference example exactly once."""
+    global _HOOKS_REGISTERED
+    if _HOOKS_REGISTERED:
+        return
+    WorkspaceResource.hooks.add(HookEvent.BEFORE_CONNECT, _seed_workspace)
+    ProjectResource.hooks.add(HookEvent.BEFORE_CONNECT, _seed_project)
+    TaskStreamResource.hooks.add(HookEvent.BEFORE_RECEIVE, _record_receive)
+    TaskStreamResource.hooks.add(HookEvent.AFTER_RECEIVE, _record_receive_result)
+    _HOOKS_REGISTERED = True
+
+
+register_reference_hooks()

--- a/examples/reference_app/resources.py
+++ b/examples/reference_app/resources.py
@@ -298,7 +298,6 @@ class TaskStreamResource(WebSocketResource):
         *operation_args: object,
     ) -> None:
         """Execute a task operation and send the standardized response."""
-
         workspace_id = typ.cast("str", self.state["workspace_id"])
         project_id = typ.cast("str", self.state["project_id"])
         task = await config.repo_operation(

--- a/examples/reference_app/resources.py
+++ b/examples/reference_app/resources.py
@@ -131,6 +131,22 @@ class TaskStreamResource(WebSocketResource):
         self._feed = announcement_feed
         self._conn_mgr = conn_mgr
         self._conn_id: str | None = None
+        self._complete_config = TaskOperationConfig(
+            repo_operation=self._repo.complete_task,
+            response_type="task.completed",
+            payload_builder=lambda task: {
+                "task_id": task.task_id,
+                "completed": task.completed,
+            },
+        )
+        self._assign_config = TaskOperationConfig(
+            repo_operation=self._repo.assign_task,
+            response_type="task.assigned",
+            payload_builder=lambda task: {
+                "task_id": task.task_id,
+                "assignee": task.assigned_to,
+            },
+        )
 
     async def on_connect(
         self,
@@ -218,18 +234,7 @@ class TaskStreamResource(WebSocketResource):
     @handles_message("task.complete")
     async def handle_complete(self, ws: WebSocketLike, payload: CompleteTask) -> None:
         """Mark a task as complete and acknowledge the caller."""
-        await self._execute_task_operation(
-            ws,
-            payload.task_id,
-            TaskOperationConfig(
-                repo_operation=self._repo.complete_task,
-                response_type="task.completed",
-                payload_builder=lambda task: {
-                    "task_id": task.task_id,
-                    "completed": task.completed,
-                },
-            ),
-        )
+        await self._execute_task_operation(ws, payload.task_id, self._complete_config)
 
     @handles_message("task.assign")
     async def handle_assign(self, ws: WebSocketLike, payload: AssignTask) -> None:
@@ -237,14 +242,7 @@ class TaskStreamResource(WebSocketResource):
         await self._execute_task_operation(
             ws,
             payload.task_id,
-            TaskOperationConfig(
-                repo_operation=self._repo.assign_task,
-                response_type="task.assigned",
-                payload_builder=lambda task: {
-                    "task_id": task.task_id,
-                    "assignee": task.assigned_to,
-                },
-            ),
+            self._assign_config,
             payload.assignee,
         )
 

--- a/examples/reference_app/resources.py
+++ b/examples/reference_app/resources.py
@@ -108,7 +108,7 @@ class ProjectResource(WebSocketResource):
 class TaskOperationConfig:
     """Configuration for a task operation handler."""
 
-    repo_operation: typ.Callable[..., Task]
+    repo_operation: typ.Callable[..., typ.Awaitable[Task]]
     response_type: str
     payload_builder: typ.Callable[[Task], dict[str, object]]
 

--- a/examples/reference_app/resources.py
+++ b/examples/reference_app/resources.py
@@ -84,10 +84,23 @@ class WorkspaceResource(WebSocketResource):
         *,
         workspace_repo: WorkspaceRepository,
         audit_trail: AuditTrail,
+        announcement_feed: AnnouncementFeed,
+        conn_mgr: WebSocketConnectionManager,
     ) -> None:
         self._repo = workspace_repo
         self._audit = audit_trail
+        self._feed = announcement_feed
+        self._conn_mgr = conn_mgr
         self.add_subroute("projects/{project_id}", ProjectResource)
+
+    def get_child_context(self) -> dict[str, object]:
+        """Provide constructor kwargs for the nested project resource."""
+        return {
+            "workspace_repo": self._repo,
+            "audit_trail": self._audit,
+            "announcement_feed": self._feed,
+            "conn_mgr": self._conn_mgr,
+        }
 
 
 class ProjectResource(WebSocketResource):
@@ -98,10 +111,23 @@ class ProjectResource(WebSocketResource):
         *,
         workspace_repo: WorkspaceRepository,
         audit_trail: AuditTrail,
+        announcement_feed: AnnouncementFeed,
+        conn_mgr: WebSocketConnectionManager,
     ) -> None:
         self._repo = workspace_repo
         self._audit = audit_trail
+        self._feed = announcement_feed
+        self._conn_mgr = conn_mgr
         self.add_subroute("tasks", TaskStreamResource)
+
+    def get_child_context(self) -> dict[str, object]:
+        """Share dependencies with the nested task stream resource."""
+        return {
+            "workspace_repo": self._repo,
+            "audit_trail": self._audit,
+            "announcement_feed": self._feed,
+            "conn_mgr": self._conn_mgr,
+        }
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -159,28 +185,34 @@ class TaskStreamResource(WebSocketResource):
         """Attach the websocket to the workspace-wide room."""
         conn_id = secrets.token_hex(12)
         await self._conn_mgr.add_connection(conn_id, ws)
-        await self._conn_mgr.join_room(conn_id, _workspace_room(workspace_id))
         self._conn_id = conn_id
-        self.state.setdefault("workspace_id", workspace_id)
-        self.state["project_id"] = project_id
-        self.state["user"] = req.get_header("x-user", default="guest")
-        await self._audit.record(
-            "session.open",
-            connection=conn_id,
-            workspace=workspace_id,
-            project=project_id,
-            user=self.state["user"],
-        )
-        await ws.send_media(
-            {
-                "type": "session.ready",
-                "payload": {
-                    "workspace": workspace_id,
-                    "project": project_id,
-                },
-            }
-        )
-        return True
+        try:
+            await self._conn_mgr.join_room(conn_id, _workspace_room(workspace_id))
+            self.state.setdefault("workspace_id", workspace_id)
+            self.state["project_id"] = project_id
+            self.state["user"] = req.get_header("x-user", default="guest")
+            await self._audit.record(
+                "session.open",
+                connection=conn_id,
+                workspace=workspace_id,
+                project=project_id,
+                user=self.state["user"],
+            )
+            await ws.send_media(
+                {
+                    "type": "session.ready",
+                    "payload": {
+                        "workspace": workspace_id,
+                        "project": project_id,
+                    },
+                }
+            )
+        except Exception:
+            await self._conn_mgr.remove_connection(conn_id)
+            self._conn_id = None
+            raise
+        else:
+            return True
 
     async def on_disconnect(self, ws: WebSocketLike, close_code: int) -> None:
         """Remove the websocket from the connection manager on disconnect."""
@@ -316,7 +348,9 @@ async def _seed_workspace(context: HookContext) -> None:
     resource = typ.cast("WorkspaceResource", context.resource)
     if not context.params:
         return
-    workspace_id = typ.cast("str", context.params.get("workspace_id"))
+    workspace_id = context.params.get("workspace_id")
+    if not isinstance(workspace_id, str):
+        return
     workspace = await resource._repo.ensure_workspace(workspace_id)
     resource.state["workspace_id"] = workspace_id
     resource.state["workspace_name"] = workspace.name
@@ -326,8 +360,10 @@ async def _seed_workspace(context: HookContext) -> None:
 async def _seed_project(context: HookContext) -> None:
     resource = typ.cast("ProjectResource", context.resource)
     params = context.params or {}
-    workspace_id = typ.cast("str", params.get("workspace_id"))
-    project_id = typ.cast("str", params.get("project_id"))
+    workspace_id = params.get("workspace_id")
+    project_id = params.get("project_id")
+    if not isinstance(workspace_id, str) or not isinstance(project_id, str):
+        return
     project = await resource._repo.ensure_project(workspace_id, project_id)
     resource.state["workspace_id"] = workspace_id
     resource.state["project_id"] = project_id
@@ -368,6 +404,3 @@ def register_reference_hooks() -> None:
     TaskStreamResource.hooks.add(HookEvent.BEFORE_RECEIVE, _record_receive)
     TaskStreamResource.hooks.add(HookEvent.AFTER_RECEIVE, _record_receive_result)
     _HOOKS_REGISTERED = True
-
-
-register_reference_hooks()

--- a/examples/reference_app/resources.py
+++ b/examples/reference_app/resources.py
@@ -16,6 +16,8 @@ from falcon_pachinko import (
 )
 from falcon_pachinko.hooks import HookContext, HookEvent
 
+from .services import Task, TaskCreationParams
+
 if typ.TYPE_CHECKING:  # pragma: no cover - typing helpers
     import falcon
 
@@ -128,7 +130,6 @@ class TaskStreamResource(WebSocketResource):
         *,
         workspace_id: str,
         project_id: str,
-        user: str | None = None,
     ) -> bool:
         """Attach the websocket to the workspace-wide room."""
         conn_id = secrets.token_hex(12)
@@ -137,7 +138,7 @@ class TaskStreamResource(WebSocketResource):
         self._conn_id = conn_id
         self.state.setdefault("workspace_id", workspace_id)
         self.state["project_id"] = project_id
-        self.state["user"] = user or req.get_header("x-user", default="guest")
+        self.state["user"] = req.get_header("x-user", default="guest")
         await self._audit.record(
             "session.open",
             connection=conn_id,
@@ -177,10 +178,12 @@ class TaskStreamResource(WebSocketResource):
         await self._repo.add_task(
             workspace_id,
             project_id,
-            task_id=payload.task_id,
-            title=payload.title,
-            author=typ.cast("str", self.state.get("user", "guest")),
-            assignee=payload.assignee,
+            TaskCreationParams(
+                task_id=payload.task_id,
+                title=payload.title,
+                author=typ.cast("str", self.state.get("user", "guest")),
+                assignee=payload.assignee,
+            ),
         )
         await ws.send_media(
             {
@@ -206,35 +209,24 @@ class TaskStreamResource(WebSocketResource):
     @handles_message("task.complete")
     async def handle_complete(self, ws: WebSocketLike, payload: CompleteTask) -> None:
         """Mark a task as complete and acknowledge the caller."""
-        workspace_id = typ.cast("str", self.state["workspace_id"])
-        project_id = typ.cast("str", self.state["project_id"])
-        task = await self._repo.complete_task(workspace_id, project_id, payload.task_id)
-        await ws.send_media(
-            {
-                "type": "task.completed",
-                "payload": {
-                    "task_id": task.task_id,
-                    "completed": task.completed,
-                },
-            }
+        await self._execute_task_operation(
+            ws,
+            payload.task_id,
+            self._repo.complete_task,
+            "task.completed",
+            lambda task: {"task_id": task.task_id, "completed": task.completed},
         )
 
     @handles_message("task.assign")
     async def handle_assign(self, ws: WebSocketLike, payload: AssignTask) -> None:
         """Reassign a task and echo the new owner."""
-        workspace_id = typ.cast("str", self.state["workspace_id"])
-        project_id = typ.cast("str", self.state["project_id"])
-        task = await self._repo.assign_task(
-            workspace_id, project_id, payload.task_id, payload.assignee
-        )
-        await ws.send_media(
-            {
-                "type": "task.assigned",
-                "payload": {
-                    "task_id": task.task_id,
-                    "assignee": task.assigned_to,
-                },
-            }
+        await self._execute_task_operation(
+            ws,
+            payload.task_id,
+            self._repo.assign_task,
+            "task.assigned",
+            lambda task: {"task_id": task.task_id, "assignee": task.assigned_to},
+            payload.assignee,
         )
 
     @handles_message("task.list", strict=False)
@@ -276,6 +268,30 @@ class TaskStreamResource(WebSocketResource):
             {
                 "type": "error",
                 "payload": "unsupported message",
+            }
+        )
+
+    async def _execute_task_operation(
+        self,
+        ws: WebSocketLike,
+        task_id: str,
+        repo_operation: typ.Callable[..., Task],
+        response_type: str,
+        payload_builder: typ.Callable[[Task], dict[str, object]],
+        *operation_args: object,
+    ) -> None:
+        workspace_id = typ.cast("str", self.state["workspace_id"])
+        project_id = typ.cast("str", self.state["project_id"])
+        task = await repo_operation(
+            workspace_id,
+            project_id,
+            task_id,
+            *operation_args,
+        )
+        await ws.send_media(
+            {
+                "type": response_type,
+                "payload": payload_builder(task),
             }
         )
 

--- a/examples/reference_app/server.py
+++ b/examples/reference_app/server.py
@@ -1,0 +1,210 @@
+"""Reference example wiring showcasing the advanced feature set."""
+
+# /// script
+# dependencies = [
+#     "falcon",
+#     "falcon-pachinko",
+#     "msgspec",
+#     "uvicorn",
+# ]
+# ///
+
+from __future__ import annotations
+
+import contextlib as cl
+import typing as typ
+
+import falcon
+import falcon.asgi as falcon_asgi
+
+from falcon_pachinko import (
+    ServiceContainer,
+    WebSocketResource,
+    WebSocketRouter,
+    WorkerController,
+    install,
+)
+from falcon_pachinko.hooks import HookContext, HookEvent
+
+from .resources import WorkspaceResource
+from .services import (
+    AnnouncementFeed,
+    AuditTrail,
+    AuthenticationError,
+    TokenAuthenticator,
+    WorkspaceRepository,
+)
+from .workers import announcement_worker
+
+try:  # pragma: no cover - used when tests are available
+    from tests.behaviour._lifespan import LifespanApp
+except ImportError:  # pragma: no cover - fallback when running the script
+
+    class LifespanApp(falcon_asgi.App):
+        """Falcon App variant exposing ``@app.lifespan`` for uvicorn."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._lifespan_handler: (
+                typ.Callable[[LifespanApp], cl.AbstractAsyncContextManager[None]] | None
+            ) = None
+
+        def lifespan(  # type: ignore[override]
+            self, fn: typ.Callable[[LifespanApp], typ.AsyncIterator[None]]
+        ) -> typ.Callable[[LifespanApp], cl.AbstractAsyncContextManager[None]]:
+            """Register ``fn`` as the lifespan context manager."""
+            manager = cl.asynccontextmanager(fn)
+            self._lifespan_handler = manager
+            return manager
+
+        def lifespan_context(self) -> cl.AbstractAsyncContextManager[None]:
+            """Return the active lifespan context manager."""
+            if self._lifespan_handler is None:
+                msg = "lifespan handler not set"
+                raise RuntimeError(msg)
+            return self._lifespan_handler(self)
+
+
+if typ.TYPE_CHECKING:  # pragma: no cover - typing helpers
+    from falcon_pachinko.protocols import WebSocketLike
+    from falcon_pachinko.router import SimulatorFactory
+    from falcon_pachinko.websocket import WebSocketConnectionManager
+else:  # pragma: no cover - runtime aliases for annotations
+    WebSocketLike = typ.Any  # type: ignore[assignment]
+    SimulatorFactory = typ.Any  # type: ignore[assignment]
+    WebSocketConnectionManager = typ.Any  # type: ignore[assignment]
+
+    class _SupportsWebSocketRoute(typ.Protocol):
+        def add_websocket_route(
+            self,
+            uri_template: str,
+            resource: type[WebSocketResource] | typ.Callable[..., WebSocketResource],
+            *args: object,
+            **kwargs: object,
+        ) -> None: ...
+
+
+class RouterEndpoint(WebSocketResource):
+    """Adapter that wires a :class:`WebSocketRouter` into the app."""
+
+    def __init__(self, *, router: WebSocketRouter) -> None:
+        self._router = router
+
+    async def on_connect(
+        self, req: falcon.Request, ws: WebSocketLike, **params: object
+    ) -> bool:
+        """Delegate the connection lifecycle to the router."""
+        await self._router.on_websocket(req, ws)
+        return False
+
+
+def _require_token_hook(
+    authenticator: TokenAuthenticator,
+) -> typ.Callable[[HookContext], typ.Awaitable[None]]:
+    async def _hook(context: HookContext) -> None:
+        params = context.params or {}
+        workspace_id = typ.cast("str | None", params.get("workspace_id"))
+        token = context.req.get_header("x-workspace-token") if context.req else None
+        try:
+            await authenticator.verify(workspace_id or "default", token)
+        except AuthenticationError as exc:
+            raise falcon.HTTPUnauthorized(description=str(exc)) from exc
+
+    return _hook
+
+
+def _inject_user_param() -> typ.Callable[[HookContext], typ.Awaitable[None] | None]:
+    async def _hook(context: HookContext) -> None:
+        if context.req is None:
+            return
+        user = context.req.get_header("x-user", default="guest")
+        params = context.params or {}
+        params.setdefault("user", user)
+        context.params = params
+
+    return _hook
+
+
+def build_container(conn_mgr: WebSocketConnectionManager) -> ServiceContainer:
+    """Create and populate the service container used for DI."""
+    container = ServiceContainer()
+    repo = WorkspaceRepository()
+    audit = AuditTrail()
+    feed = AnnouncementFeed()
+    authenticator = TokenAuthenticator({"atlas": "seekrit", "zephyr": "seekrit"})
+    container.register("workspace_repo", repo)
+    container.register("audit_trail", audit)
+    container.register("announcement_feed", feed)
+    container.register("conn_mgr", conn_mgr)
+    container.register("token_authenticator", authenticator)
+    return container
+
+
+def build_router(
+    container: ServiceContainer,
+    *,
+    simulator_factory: SimulatorFactory | None = None,
+    resource_factory: typ.Callable[
+        [typ.Callable[..., WebSocketResource]], WebSocketResource
+    ]
+    | None = None,
+) -> WebSocketRouter:
+    """Construct the router with routes, hooks, and DI wiring."""
+    router = WebSocketRouter(
+        name="reference",
+        resource_factory=resource_factory or container.create_resource,
+        simulator_factory=simulator_factory,
+    )
+    router.add_route(
+        "/workspaces/{workspace_id}",
+        WorkspaceResource,
+        name="workspace",
+    )
+    router.mount("/ws")
+
+    authenticator = typ.cast(
+        "TokenAuthenticator", container.resolve("token_authenticator")
+    )
+    router.global_hooks.add(
+        HookEvent.BEFORE_CONNECT, _require_token_hook(authenticator)
+    )
+    router.global_hooks.add(HookEvent.BEFORE_CONNECT, _inject_user_param())
+    return router
+
+
+def create_app() -> LifespanApp:
+    """Create the Falcon ASGI app with the full reference configuration."""
+    app = LifespanApp()
+    install(app)
+    conn_mgr = typ.cast(
+        "WebSocketConnectionManager",
+        app.ws_connection_manager,
+    )
+    container = build_container(conn_mgr)
+    router = build_router(container)
+
+    ws_app = typ.cast("_SupportsWebSocketRoute", app)
+    ws_app.add_websocket_route("/ws", RouterEndpoint, router=router)
+
+    controller = WorkerController()
+    feed = typ.cast("AnnouncementFeed", container.resolve("announcement_feed"))
+
+    @app.lifespan
+    async def lifespan(_app: LifespanApp) -> typ.AsyncIterator[None]:
+        await controller.start(
+            announcement_worker,
+            conn_mgr=conn_mgr,
+            announcement_feed=feed,
+        )
+        try:
+            yield
+        finally:
+            await controller.stop()
+
+    return app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    import uvicorn
+
+    uvicorn.run(create_app(), host="127.0.0.1", port=8000)

--- a/examples/reference_app/server.py
+++ b/examples/reference_app/server.py
@@ -26,7 +26,7 @@ from falcon_pachinko import (
 )
 from falcon_pachinko.hooks import HookContext, HookEvent
 
-from .resources import WorkspaceResource
+from .resources import WorkspaceResource, register_reference_hooks
 from .services import (
     AnnouncementFeed,
     AuditTrail,
@@ -150,6 +150,7 @@ def build_router(
     | None = None,
 ) -> WebSocketRouter:
     """Construct the router with routes, hooks, and DI wiring."""
+    register_reference_hooks()
     router = WebSocketRouter(
         name="reference",
         resource_factory=resource_factory or container.create_resource,

--- a/examples/reference_app/services.py
+++ b/examples/reference_app/services.py
@@ -12,6 +12,7 @@ __all__ = [
     "AuthenticationError",
     "Project",
     "Task",
+    "TaskCreationParams",
     "TokenAuthenticator",
     "Workspace",
     "WorkspaceRepository",
@@ -27,6 +28,16 @@ class Task:
     created_by: str
     assigned_to: str | None = None
     completed: bool = False
+
+
+@dc.dataclass(slots=True)
+class TaskCreationParams:
+    """Parameter object capturing task creation details."""
+
+    task_id: str
+    title: str
+    author: str
+    assignee: str | None = None
 
 
 @dc.dataclass(slots=True)
@@ -69,22 +80,18 @@ class WorkspaceRepository:
         self,
         workspace_id: str,
         project_id: str,
-        *,
-        task_id: str,
-        title: str,
-        author: str,
-        assignee: str | None = None,
+        params: TaskCreationParams,
     ) -> Task:
         """Store a new task and return it."""
         async with self._lock:
             project = self._ensure_project_locked(workspace_id, project_id)
             task = Task(
-                task_id=task_id,
-                title=title,
-                created_by=author,
-                assigned_to=assignee,
+                task_id=params.task_id,
+                title=params.title,
+                created_by=params.author,
+                assigned_to=params.assignee,
             )
-            project.tasks[task_id] = task
+            project.tasks[task.task_id] = task
             return task
 
     async def complete_task(

--- a/examples/reference_app/services.py
+++ b/examples/reference_app/services.py
@@ -233,3 +233,4 @@ class TokenAuthenticator:
             return
         if token != expected:
             raise AuthenticationError(workspace_id)
+        return

--- a/examples/reference_app/services.py
+++ b/examples/reference_app/services.py
@@ -1,0 +1,228 @@
+"""Support services used by the reference application example."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses as dc
+import typing as typ
+
+__all__ = [
+    "AnnouncementFeed",
+    "AuditTrail",
+    "AuthenticationError",
+    "Project",
+    "Task",
+    "TokenAuthenticator",
+    "Workspace",
+    "WorkspaceRepository",
+]
+
+
+@dc.dataclass(slots=True)
+class Task:
+    """Represents a single task tracked inside a project."""
+
+    task_id: str
+    title: str
+    created_by: str
+    assigned_to: str | None = None
+    completed: bool = False
+
+
+@dc.dataclass(slots=True)
+class Project:
+    """Aggregate of tasks grouped under a logical project."""
+
+    project_id: str
+    name: str
+    tasks: dict[str, Task]
+
+
+@dc.dataclass(slots=True)
+class Workspace:
+    """Collection of projects owned by a workspace."""
+
+    workspace_id: str
+    name: str
+    projects: dict[str, Project]
+
+
+class WorkspaceRepository:
+    """In-memory repository coordinating workspaces, projects, and tasks."""
+
+    def __init__(self) -> None:
+        self._workspaces: dict[str, Workspace] = {}
+        self._lock = asyncio.Lock()
+
+    async def ensure_workspace(self, workspace_id: str) -> Workspace:
+        """Return an existing workspace or create a new one."""
+        async with self._lock:
+            return self._get_or_create_workspace(workspace_id)
+
+    async def ensure_project(self, workspace_id: str, project_id: str) -> Project:
+        """Return a project, creating it and its parent workspace if needed."""
+        async with self._lock:
+            workspace = self._get_or_create_workspace(workspace_id)
+            return self._get_or_create_project(workspace, project_id)
+
+    async def add_task(
+        self,
+        workspace_id: str,
+        project_id: str,
+        *,
+        task_id: str,
+        title: str,
+        author: str,
+        assignee: str | None = None,
+    ) -> Task:
+        """Store a new task and return it."""
+        async with self._lock:
+            project = self._ensure_project_locked(workspace_id, project_id)
+            task = Task(
+                task_id=task_id,
+                title=title,
+                created_by=author,
+                assigned_to=assignee,
+            )
+            project.tasks[task_id] = task
+            return task
+
+    async def complete_task(
+        self, workspace_id: str, project_id: str, task_id: str
+    ) -> Task:
+        """Mark ``task_id`` as completed and return it."""
+        async with self._lock:
+            project = self._ensure_project_locked(workspace_id, project_id)
+            task = project.tasks[task_id]
+            task.completed = True
+            return task
+
+    async def assign_task(
+        self, workspace_id: str, project_id: str, task_id: str, assignee: str
+    ) -> Task:
+        """Assign ``task_id`` to ``assignee`` and return it."""
+        async with self._lock:
+            project = self._ensure_project_locked(workspace_id, project_id)
+            task = project.tasks[task_id]
+            task.assigned_to = assignee
+            return task
+
+    async def list_tasks(
+        self,
+        workspace_id: str,
+        project_id: str,
+        *,
+        include_completed: bool = True,
+    ) -> list[Task]:
+        """Return a snapshot of tasks filtered by completion state."""
+        async with self._lock:
+            project = self._ensure_project_locked(workspace_id, project_id)
+            tasks = list(project.tasks.values())
+
+        if include_completed:
+            return [dc.replace(task) for task in tasks]
+        return [dc.replace(task) for task in tasks if not task.completed]
+
+    async def snapshot(self) -> dict[str, Workspace]:
+        """Return a deep-ish copy of the repository contents for inspection."""
+        async with self._lock:
+            return {
+                wid: Workspace(
+                    workspace_id=workspace.workspace_id,
+                    name=workspace.name,
+                    projects={
+                        pid: Project(
+                            project_id=project.project_id,
+                            name=project.name,
+                            tasks={
+                                tid: dc.replace(task)
+                                for tid, task in project.tasks.items()
+                            },
+                        )
+                        for pid, project in workspace.projects.items()
+                    },
+                )
+                for wid, workspace in self._workspaces.items()
+            }
+
+    def _get_or_create_workspace(self, workspace_id: str) -> Workspace:
+        workspace = self._workspaces.get(workspace_id)
+        if workspace is None:
+            workspace = Workspace(
+                workspace_id=workspace_id,
+                name=workspace_id.replace("-", " ").title(),
+                projects={},
+            )
+            self._workspaces[workspace_id] = workspace
+        return workspace
+
+    def _get_or_create_project(self, workspace: Workspace, project_id: str) -> Project:
+        project = workspace.projects.get(project_id)
+        if project is None:
+            project = Project(
+                project_id=project_id,
+                name=project_id.replace("-", " ").title(),
+                tasks={},
+            )
+            workspace.projects[project_id] = project
+        return project
+
+    def _ensure_project_locked(self, workspace_id: str, project_id: str) -> Project:
+        workspace = self._get_or_create_workspace(workspace_id)
+        return self._get_or_create_project(workspace, project_id)
+
+
+class AuditTrail:
+    """Simple async-friendly audit recorder used by the hooks."""
+
+    def __init__(self) -> None:
+        self._records: list[dict[str, object]] = []
+        self._lock = asyncio.Lock()
+
+    @property
+    def records(self) -> list[dict[str, object]]:
+        """Return a copy of the recorded events."""
+        return list(self._records)
+
+    async def record(self, event: str, **metadata: object) -> None:
+        """Append an audit entry describing ``event``."""
+        async with self._lock:
+            self._records.append({"event": event, "metadata": metadata})
+
+
+class AnnouncementFeed:
+    """Async queue used by workers to broadcast state changes."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[tuple[str, dict[str, object]]] = asyncio.Queue()
+
+    async def publish(self, workspace_id: str, payload: dict[str, object]) -> None:
+        """Publish ``payload`` for ``workspace_id`` subscribers."""
+        await self._queue.put((workspace_id, payload))
+
+    async def next_event(self) -> tuple[str, dict[str, object]]:
+        """Wait for the next announcement event."""
+        return await self._queue.get()
+
+
+class AuthenticationError(PermissionError):
+    """Raised when a connection presents invalid credentials."""
+
+    def __init__(self, workspace_id: str) -> None:
+        self.workspace_id = workspace_id
+        super().__init__(f"invalid token for workspace {workspace_id!r}")
+
+
+class TokenAuthenticator:
+    """Trivial header-based authenticator wired into global hooks."""
+
+    def __init__(self, secrets: typ.Mapping[str, str]) -> None:
+        self._secrets = dict(secrets)
+
+    async def verify(self, workspace_id: str, token: str | None) -> None:
+        """Ensure ``token`` matches the configured secret for the workspace."""
+        expected = self._secrets.get(workspace_id)
+        if expected is None:
+            return
+        if token != expected:
+            raise AuthenticationError(workspace_id)

--- a/examples/reference_app/workers.py
+++ b/examples/reference_app/workers.py
@@ -1,0 +1,35 @@
+"""Background workers used by the reference application."""
+
+from __future__ import annotations
+
+import asyncio
+import typing as typ
+
+from falcon_pachinko import worker
+
+from .resources import _workspace_room
+
+__all__ = ["announcement_worker"]
+
+if typ.TYPE_CHECKING:  # pragma: no cover - typing helpers
+    from falcon_pachinko import WebSocketConnectionManager
+
+    from .services import AnnouncementFeed
+else:  # pragma: no cover - runtime aliases for annotations
+    AnnouncementFeed = typ.Any  # type: ignore[assignment]
+    WebSocketConnectionManager = typ.Any  # type: ignore[assignment]
+
+
+@worker
+async def announcement_worker(
+    *,
+    conn_mgr: WebSocketConnectionManager,
+    announcement_feed: AnnouncementFeed,
+) -> None:
+    """Broadcast feed updates to everyone listening within a workspace."""
+    try:
+        while True:
+            workspace_id, payload = await announcement_feed.next_event()
+            await conn_mgr.broadcast_to_room(_workspace_room(workspace_id), payload)
+    except asyncio.CancelledError:
+        return

--- a/falcon_pachinko/testing/client.py
+++ b/falcon_pachinko/testing/client.py
@@ -429,12 +429,16 @@ class WebSocketTestClient:
             negotiated,
         ) = self._prepare_connection_params(path, headers, subprotocols)
         trace_log = self._configure_trace(trace=trace)
-        async with ws_connect(
-            url,
-            extra_headers=merged_headers,
-            subprotocols=negotiated,
-            open_timeout=self._open_timeout,
-        ) as connection:
+        connect_cm = typ.cast(
+            "typ.AsyncContextManager[WebSocketClientProtocol]",
+            ws_connect(
+                url,
+                extra_headers=merged_headers,
+                subprotocols=negotiated,
+                open_timeout=self._open_timeout,
+            ),
+        )
+        async with connect_cm as connection:
             session = WebSocketSession(
                 connection,
                 path=normalized_path,

--- a/tests/behaviour/reference_example.feature
+++ b/tests/behaviour/reference_example.feature
@@ -1,0 +1,12 @@
+Feature: Full reference example workflow
+  The comprehensive example application should exercise the advanced
+  features provided by the router, including dependency injection,
+  schema-driven dispatch, hooks, and connection state management.
+
+  Scenario: Task creation flows through the router, schema dispatch, and feed
+    Given the reference router with a recording factory
+    When a client connects to "/ws/workspaces/atlas/projects/triage/tasks" using token "seekrit" as user "casey"
+    And they send a "task.add" message for task "T-42"
+    Then the connection is accepted
+    And the task stream resource replies with a task acknowledgement
+    And the announcement feed captures an event for workspace "atlas"

--- a/tests/behaviour/test_connection_manager_steps.py
+++ b/tests/behaviour/test_connection_manager_steps.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses as dc
+import typing as typ
 
 from pytest_bdd import given, scenario, then, when
 
@@ -70,7 +71,10 @@ async def _iterate_lobby(
     exclude: set[str] | None = None,
 ) -> list[DummyWebSocket]:
     """Collect websockets yielded when iterating the lobby."""
-    return [ws async for ws in mgr.connections(room="lobby", exclude=exclude)]
+    return [
+        typ.cast("DummyWebSocket", ws)
+        async for ws in mgr.connections(room="lobby", exclude=exclude)
+    ]
 
 
 @scenario(

--- a/tests/behaviour/test_reference_example_steps.py
+++ b/tests/behaviour/test_reference_example_steps.py
@@ -1,0 +1,169 @@
+"""Behavioural tests covering the full reference example workflow."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses as dc
+import typing as typ
+
+import msgspec.json as msjson
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+from examples.reference_app import build_container, build_router
+from examples.reference_app.resources import AddTask, TaskStreamResource
+from falcon_pachinko.testing import WebSocketSimulator
+from falcon_pachinko.websocket import WebSocketConnectionManager
+
+if typ.TYPE_CHECKING:  # pragma: no cover - typing helpers
+    import falcon
+
+    from examples.reference_app.services import AnnouncementFeed
+    from falcon_pachinko import ServiceContainer, WebSocketResource, WebSocketRouter
+else:  # pragma: no cover - runtime aliases for annotations
+    AnnouncementFeed = typ.Any  # type: ignore[assignment]
+    ServiceContainer = typ.Any  # type: ignore[assignment]
+    WebSocketResource = typ.Any  # type: ignore[assignment]
+    WebSocketRouter = typ.Any  # type: ignore[assignment]
+    falcon = typ.Any  # type: ignore[assignment]
+
+
+@dc.dataclass
+class ReferenceScenario:
+    """Container for shared reference example state."""
+
+    router: WebSocketRouter
+    container: ServiceContainer
+    feed: AnnouncementFeed
+    simulator: WebSocketSimulator
+    instances: list[WebSocketResource]
+    resource: TaskStreamResource | None = None
+    last_event: tuple[str, dict[str, object]] | None = None
+
+
+_MISSING_TASK_RESOURCE_MSG = "TaskStreamResource was not instantiated"
+
+
+class _RequestStub:
+    def __init__(self, path: str, headers: dict[str, str]) -> None:
+        self.path = path
+        self.path_template = "/ws"
+        self._headers = {key.lower(): value for key, value in headers.items()}
+
+    def get_header(self, name: str, default: str | None = None) -> str | None:
+        return self._headers.get(name.lower(), default)
+
+
+@pytest.fixture
+def event_loop() -> typ.Iterator[asyncio.AbstractEventLoop]:
+    """Provide an isolated event loop per test."""
+    loop = asyncio.new_event_loop()
+    try:
+        yield loop
+    finally:
+        loop.close()
+
+
+@scenario(
+    "reference_example.feature",
+    "Task creation flows through the router, schema dispatch, and feed",
+)
+def test_reference_example() -> None:  # pragma: no cover - scenario registration
+    """Scenario registration for pytest-bdd."""
+
+
+@given("the reference router with a recording factory", target_fixture="context")
+def given_reference_router(event_loop: asyncio.AbstractEventLoop) -> ReferenceScenario:
+    """Build the router wiring using the shared DI container."""
+    conn_mgr = WebSocketConnectionManager()
+    container = build_container(conn_mgr)
+    feed = typ.cast("AnnouncementFeed", container.resolve("announcement_feed"))
+    instances: list[WebSocketResource] = []
+
+    def recording_factory(
+        route_factory: typ.Callable[..., WebSocketResource],
+    ) -> WebSocketResource:
+        instance = container.create_resource(route_factory)
+        instances.append(instance)
+        return instance
+
+    simulator = WebSocketSimulator()
+    router = build_router(
+        container,
+        simulator_factory=lambda *_: simulator,
+        resource_factory=recording_factory,
+    )
+    return ReferenceScenario(
+        router=router,
+        container=container,
+        feed=feed,
+        simulator=simulator,
+        instances=instances,
+    )
+
+
+def _select_task_resource(instances: list[WebSocketResource]) -> TaskStreamResource:
+    for instance in reversed(instances):
+        if isinstance(instance, TaskStreamResource):
+            return instance
+    raise AssertionError(_MISSING_TASK_RESOURCE_MSG)
+
+
+@when(
+    'a client connects to "/ws/workspaces/atlas/projects/triage/tasks" '
+    'using token "seekrit" as user "casey"',
+    target_fixture="context",
+)
+def when_client_connects(
+    context: ReferenceScenario, event_loop: asyncio.AbstractEventLoop
+) -> ReferenceScenario:
+    """Dispatch a connection through the router with valid headers."""
+    req = _RequestStub(
+        path="/ws/workspaces/atlas/projects/triage/tasks",
+        headers={"x-workspace-token": "seekrit", "x-user": "casey"},
+    )
+    event_loop.run_until_complete(
+        context.router.on_websocket(typ.cast("falcon.Request", req), context.simulator)
+    )
+    context.resource = _select_task_resource(context.instances)
+    return context
+
+
+@when('they send a "task.add" message for task "T-42"', target_fixture="context")
+def when_send_task_add(
+    context: ReferenceScenario, event_loop: asyncio.AbstractEventLoop
+) -> ReferenceScenario:
+    """Dispatch a schema-defined message through the active resource."""
+    resource = typ.cast("TaskStreamResource", context.resource)
+    payload = AddTask(task_id="T-42", title="Investigate event loop")
+    raw = msjson.encode(payload)
+    event_loop.run_until_complete(resource.dispatch(context.simulator, raw))
+    context.last_event = typ.cast(
+        "tuple[str, dict[str, object]]",
+        event_loop.run_until_complete(context.feed.next_event()),
+    )
+    return context
+
+
+@then("the connection is accepted")
+def then_connection(context: ReferenceScenario) -> None:
+    """Ensure the simulator recorded the handshake acceptance."""
+    assert context.simulator.accepted is True
+
+
+@then("the task stream resource replies with a task acknowledgement")
+def then_acknowledgement(context: ReferenceScenario) -> None:
+    """Check that the last frame is the expected acknowledgement."""
+    message = typ.cast("dict[str, object]", context.simulator.sent_messages[-1])
+    assert message["type"] == "task.added"
+
+
+@then('the announcement feed captures an event for workspace "atlas"')
+def then_feed_capture(context: ReferenceScenario) -> None:
+    """Validate that the AnnouncementFeed observed the broadcast event."""
+    assert context.last_event is not None
+    workspace, payload = context.last_event
+    assert workspace == "atlas"
+    payload_dict = payload
+    nested = typ.cast("dict[str, object]", payload_dict["payload"])
+    assert nested["kind"] == "task_added"

--- a/tests/test_reference_example_unit.py
+++ b/tests/test_reference_example_unit.py
@@ -1,0 +1,136 @@
+"""Unit tests for the full reference example support modules."""
+
+from __future__ import annotations
+
+import typing as typ
+
+import falcon
+import pytest
+from falcon import HTTPUnauthorized
+
+from examples.reference_app import build_container, build_router
+from examples.reference_app.services import (
+    AnnouncementFeed,
+    AuthenticationError,
+    Task,
+    TokenAuthenticator,
+    WorkspaceRepository,
+)
+from falcon_pachinko.protocols import WebSocketLike
+from falcon_pachinko.websocket import WebSocketConnectionManager
+
+if typ.TYPE_CHECKING:  # pragma: no cover - typing helpers
+    from falcon_pachinko import ServiceContainer, WebSocketRouter
+else:  # pragma: no cover - runtime stubs for annotations
+    ServiceContainer = typ.Any  # type: ignore[assignment]
+    WebSocketRouter = typ.Any  # type: ignore[assignment]
+
+
+class _RequestStub:
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.path = "/ws/workspaces/atlas/projects/triage/tasks"
+        self.path_template = "/ws"
+        self._headers = {key.lower(): value for key, value in headers.items()}
+
+    def get_header(self, name: str, default: str | None = None) -> str | None:
+        return self._headers.get(name.lower(), default)
+
+
+class _WebSocketStub(WebSocketLike):
+    def __init__(self) -> None:
+        self.accepted = False
+        self.closed = False
+        self.close_code: int | None = None
+        self.messages: list[object] = []
+
+    async def accept(self, subprotocol: str | None = None) -> None:
+        self.accepted = True
+
+    async def close(self, code: int = 1000) -> None:
+        self.closed = True
+        self.close_code = code
+
+    async def send_media(self, data: object) -> None:
+        self.messages.append(data)
+
+    async def receive_media(self) -> object:
+        return None
+
+
+def _build_router() -> tuple[WebSocketRouter, ServiceContainer]:
+    conn_mgr = WebSocketConnectionManager()
+    container = build_container(conn_mgr)
+    router = build_router(container)
+    return router, container
+
+
+@pytest.mark.asyncio
+async def test_router_rejects_missing_token() -> None:
+    """Global hooks close connections that omit the workspace token."""
+    router, _ = _build_router()
+    req = _RequestStub(headers={})
+    ws = _WebSocketStub()
+    with pytest.raises(HTTPUnauthorized):
+        await router.on_websocket(
+            typ.cast("falcon.Request", req),
+            ws,
+        )
+    assert ws.closed is True
+    assert ws.accepted is False
+
+
+@pytest.mark.asyncio
+async def test_router_accepts_with_valid_token() -> None:
+    """Connections presenting the correct headers are accepted."""
+    router, _ = _build_router()
+    req = _RequestStub(headers={"x-workspace-token": "seekrit", "x-user": "riley"})
+    ws = _WebSocketStub()
+    await router.on_websocket(typ.cast("falcon.Request", req), ws)
+    assert ws.accepted is True
+    assert ws.messages
+    first = typ.cast("dict[str, object]", ws.messages[0])
+    assert first["type"] == "session.ready"
+
+
+@pytest.mark.asyncio
+async def test_workspace_repository_task_lifecycle() -> None:
+    """Tasks can be created, assigned, and completed within a project."""
+    repo = WorkspaceRepository()
+    await repo.add_task(
+        "atlas",
+        "triage",
+        task_id="T-1",
+        title="Investigate outage",
+        author="avery",
+        assignee="brooke",
+    )
+    task = await repo.assign_task("atlas", "triage", "T-1", "casey")
+    assert task.assigned_to == "casey"
+    task = await repo.complete_task("atlas", "triage", "T-1")
+    assert task.completed is True
+    tasks = await repo.list_tasks("atlas", "triage", include_completed=False)
+    assert tasks == []
+    tasks = await repo.list_tasks("atlas", "triage", include_completed=True)
+    assert isinstance(tasks[0], Task)
+    assert tasks[0].completed is True
+
+
+@pytest.mark.asyncio
+async def test_token_authenticator_rejects_invalid_secret() -> None:
+    """Connections presenting the wrong token raise ``AuthenticationError``."""
+    authenticator = TokenAuthenticator({"atlas": "secret"})
+    with pytest.raises(AuthenticationError):
+        await authenticator.verify("atlas", token="nope")  # noqa: S106
+    await authenticator.verify("unknown", token=None)
+
+
+@pytest.mark.asyncio
+async def test_announcement_feed_preserves_order() -> None:
+    """Announcement feed publishes events FIFO for the worker."""
+    feed = AnnouncementFeed()
+    await feed.publish("atlas", {"type": "a"})
+    await feed.publish("atlas", {"type": "b"})
+    first = await feed.next_event()
+    second = await feed.next_event()
+    assert first == ("atlas", {"type": "a"})
+    assert second == ("atlas", {"type": "b"})

--- a/tests/test_reference_example_unit.py
+++ b/tests/test_reference_example_unit.py
@@ -13,6 +13,7 @@ from examples.reference_app.services import (
     AnnouncementFeed,
     AuthenticationError,
     Task,
+    TaskCreationParams,
     TokenAuthenticator,
     WorkspaceRepository,
 )
@@ -99,10 +100,12 @@ async def test_workspace_repository_task_lifecycle() -> None:
     await repo.add_task(
         "atlas",
         "triage",
-        task_id="T-1",
-        title="Investigate outage",
-        author="avery",
-        assignee="brooke",
+        TaskCreationParams(
+            task_id="T-1",
+            title="Investigate outage",
+            author="avery",
+            assignee="brooke",
+        ),
     )
     task = await repo.assign_task("atlas", "triage", "T-1", "casey")
     assert task.assigned_to == "casey"


### PR DESCRIPTION
## Summary
- Introduces a full reference example under examples/reference_app to demonstrate Falcon-Pachinko’s advanced features end-to-end (mountable router, schema-driven dispatch, nested resources, hooks, DI, and lifespan-managed workers).
- Includes pytest-based unit tests and pytest-bdd behavioural tests to exercise the router, resources, and worker integration.
- Adds supportive services, resources, and workers, plus wiring code to run the full reference app locally.
- Updates tests and docs to reflect the new example and its testing coverage.

## Changes
- New example package: examples/reference_app
  - resources.py: WebSocket resources for WorkspaceResource → ProjectResource → TaskStreamResource with schema-driven messages and per-connection state.
  - server.py: Wiring for container, router, app creation, and lifespan-managed worker startup.
  - services.py: In-memory domain model (WorkspaceRepository, Task, Project, Workspace), AuditTrail, AnnouncementFeed, and simple TokenAuthenticator.
  - workers.py: announcement_worker broadcasting workspace announcements to connected clients.
  - __init__.py files exposing build_container, build_router, create_app APIs.
- Tests added
  - tests/behaviour/reference_example.feature: Behaviour scenario for a task creation flow through the reference app.
  - tests/behaviour/test_reference_example_steps.py: Behavioural test steps wiring the reference app with a recording factory and simulator.
  - tests/test_reference_example_unit.py: Unit tests for container/router wiring, repository lifecycle, token authentication, and announcement feed.
  - tests/behaviour/test_connection_manager_steps.py: minor typing adjustments to support new tests.
- Compatibility tweak
  - falcon_pachinko/testing/client.py: minor adjustment to WebSocket connect handling to align with new test expectations.
- Documentation
  - docs/roadmap.md: mark Build a Full Reference Example as completed and expand its description.
  - docs/falcon-websocket-extension-design.md: note about the comprehensive reference application and its role in exercising advanced features.

## Design & Implementation Highlights
- Reference application architecture
  - WorkspaceResource -> ProjectResource -> TaskStreamResource forms a nested WS router that shares a ServiceContainer for DI.
  - Hooks seed per-connection workspace/project state and record message lifecycles (BEFORE_CONNECT, BEFORE_RECEIVE, AFTER_RECEIVE).
  - A background announcement_worker publishes workspace events to all connections in a given room.
- Messaging and schemas
  - Task schema includes AddTask, CompleteTask, AssignTask, ListTasks, and BroadcastNote with tag-based dispatch.
  - Client interactions follow a concrete flow: open connection, send task.add, receive acknowledgements, and observe feed events.
- DI, authentication, and value injection
  - build_container wires in WorkspaceRepository, AuditTrail, AnnouncementFeed, a connection manager, and a TokenAuthenticator.
  - Global BEFORE_CONNECT hooks enforce token presence and inject user identity into request params.
- Testing approach
  - Unit tests validate repository lifecycles, task lifecycle methods, and token authentication failure paths.
  - Behavioural tests exercise end-to-end flow using a recording factory to capture resource instantiation and a simulator to verify connection acceptance, message handling, and feed events.

## How to Run & Test
- Install dependencies and run tests:
  - pip install -e .
  - pytest -q
- Behavioural tests rely on pytest-bdd; ensure optional websocket test dependencies are installed.
- To run the reference app locally (optional):
  - python -m examples.reference_app.server:create_app or run via UVicorn if configured as in the script (uvicorn usage available in server.py).

## Migration & Considerations
- This PR introduces a full example app intended for demonstration and testing; no existing public APIs are removed.
- The new tests supplement existing test suites and are designed to validate end-to-end behaviour of the reference app routing and worker integration.

---
If you want a quick environment to experiment with the example, you can start by inspecting:
- examples/reference_app/server.py (app wiring, container, router, worker startup)
- examples/reference_app/resources.py (WS resource pipeline and message handlers)
- examples/reference_app/services.py (in-memory domain and utilities)
- tests/behaviour and tests/test_reference_example_unit.py for representative tests and scenarios.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---
ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e089aec2-3bbe-49f8-bad3-e0b535f80e2a

## Summary by Sourcery

Add a full reference example demonstrating end-to-end WebSocket routing, DI, hooks, and worker integration with unit and behavioural tests

New Features:
- Introduce a comprehensive reference example under examples/reference_app demonstrating end-to-end WebSocket routing with schema-driven dispatch, nested resources, hooks, dependency injection, and lifespan-managed workers
- Implement domain services (WorkspaceRepository, AuditTrail, AnnouncementFeed, TokenAuthenticator) and a background announcement_worker to broadcast workspace events
- Provide example WebSocket resources (WorkspaceResource, ProjectResource, TaskStreamResource) and server wiring (container, router, app creation) for local launch

Enhancements:
- Adjust testing client WebSocket connect context manager for compatibility with new test expectations and refine typing in connection_manager steps

Documentation:
- Mark the full reference example as completed in roadmap.md and add details about the examples/reference_app in the design documentation

Tests:
- Add pytest unit tests and pytest-bdd behavioural tests to validate the reference application's routing, resource dispatch, service integration, and message flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full reference app demonstrating WebSocket task management (add/assign/complete), per-connection state, DI wiring, lifespan-managed worker for workspace announcements, and token-based auth.
* **Documentation**
  * Switched examples/docs to secure WebSocket (wss://) and expanded the roadmap with a concrete reference-app plan and usage guidance.
* **Tests**
  * Added behavior-driven and unit tests exercising connection handling, message flows, hooks, and announcement delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->