### PR TITLE
Align roadmap with the roadmap grammar

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,2 +1,0 @@
-docstrings:
-  style: numpy

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,10 @@ VENV_TOOLS = pytest
 
 all: build check-fmt test typecheck
 
-build: uv ## Build virtual-env and install deps
-	uv venv
+.venv: pyproject.toml
+	uv venv --clear
+
+build: uv .venv ## Build virtual-env and install deps
 	uv sync --group dev
 
 build-release: ## Build artefacts (sdist & wheel)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ See
  for the full design rationale. For practical guidance, start with the
 [User Guide](docs/users-guide.md) and the
 [Migration Guide](docs/migration-guide.md).
+Maintainer-facing notes live in the
+[Developer Guide](docs/developers-guide.md).
 
 ## Requirements
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1,0 +1,49 @@
+# Developer Guide
+
+This guide captures maintainer-facing conventions that are not part of the
+public user guide.
+
+## Router Request Boundary
+
+`WebSocketRouter` is mounted as a Falcon resource, but its internal dispatch
+pipeline only needs a small request surface before handing control to resource
+callbacks:
+
+- `path`: the concrete request path used for route matching.
+- `path_template`: the Falcon mount template used to verify that the request
+  belongs to the mounted router prefix.
+
+The router models that surface with the private `_RequestLike` protocol in
+`falcon_pachinko/router.py`. Internal routing helpers should accept
+`_RequestLike` instead of broad `object` parameters. This keeps request-shaped
+test doubles type-checkable while documenting the attributes the router
+actually consumes.
+
+Keep casts to `falcon.Request` at the edge where the router calls APIs whose
+public contract is Falcon-specific, such as hook notification and
+`WebSocketResource.on_connect()`. Do not widen the whole router pipeline back
+to `falcon.Request` unless those internals start depending on Falcon-only
+attributes.
+
+Test request doubles should expose both `path` and `path_template`. Use an
+empty `path_template` for root-mounted router tests, matching the runtime
+default used by Falcon-style request objects that do not provide a template.
+
+## Build Environment
+
+The `build` target owns the local virtual environment. It depends on the
+`.venv` target, which runs:
+
+```sh
+uv venv --clear
+```
+
+This deliberately replaces an existing `.venv` before `uv sync --group dev`.
+The behaviour matches CI, where a previous step may already have created the
+directory. Without `--clear`, modern `uv` exits with an error when `.venv`
+exists, causing downstream gates such as `make typecheck` to fail before they
+reach analysis.
+
+Prefer Makefile targets over invoking tools directly. When changing the
+Makefile, run `mbake validate Makefile` and the relevant commit gates before
+committing.

--- a/docs/falcon-websocket-extension-design.md
+++ b/docs/falcon-websocket-extension-design.md
@@ -573,10 +573,14 @@ conn_mgr = app.ws_connection_manager
 
 # 1. Define workers as ordinary async functions with explicit dependencies
 @worker
-async def announcement_worker(conn_mgr: pachinko.WebSocketConnectionManager) -> None:
+async def announcement_worker(
+    conn_mgr: pachinko.WebSocketConnectionManager,
+) -> None:
     """Broadcasts a heartbeat message to all sockets every 30s."""
     while True:
-        await conn_mgr.broadcast_to_all({"type": "ping"}) # Assuming a broadcast_to_all method
+        await conn_mgr.broadcast_to_all(
+            {"type": "ping"},
+        )  # Assuming a broadcast_to_all method
         await asyncio.sleep(30)
 
 # 2. Bind the worker lifecycle to the ASGI lifespan
@@ -609,16 +613,55 @@ abstractions and their intended use. This API structure is designed to be both
 powerful enough for complex applications and intuitive for developers
 accustomed to Falcon.
 
-| Component                      | Key Elements                                                  | Purpose                                                                 | Falcon Analogy              |
-| ------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------- |
-| Application Setup              | `falcon_pachinko.install(app)`                                | Initializes shared WebSocket components such as the connection manager. | App-level extensions        |
-| Route Definition               | `app.add_websocket_route()` and `WebSocketRouter.add_route()` | Maps a URI path to a `WebSocketResource`.                               | `app.add_route()`           |
-| Resource Class                 | `falcon_pachinko.WebSocketResource`                           | Handles connections and messages for a given route.                     | Falcon HTTP `Resource`      |
-| Connection Lifecycle           | `on_connect()`, `on_disconnect()`                             | Setup and teardown hooks for each connection.                           | Request/response middleware |
-| Message Handling (Typed)       | `@handles_message()` and `on_{type}`                          | Routes incoming JSON messages by type.                                  | `on_get`, `on_post`, etc.   |
-| Message Handling (Generic)     | `on_unhandled()`                                              | Fallback for unrecognized or non-JSON messages.                         | N/A                         |
-| Background Worker Integration  | `WorkerController`, `@app.lifespan`                           | Manages long-running tasks within the ASGI lifecycle.                   | Custom patterns             |
-| Connection Management (Global) | `app.ws_connection_manager`                                   | Tracks connections and enables broadcasting.                            | N/A                         |
+- **Application Setup**
+
+  - Key elements: `falcon_pachinko.install(app)`
+  - Purpose: initializes shared WebSocket components such as the connection
+    manager.
+  - Falcon analogy: app-level extensions.
+
+- **Route Definition**
+
+  - Key elements: `app.add_websocket_route()` and
+    `WebSocketRouter.add_route()`
+  - Purpose: maps a URI path to a `WebSocketResource`.
+  - Falcon analogy: `app.add_route()`.
+
+- **Resource Class**
+
+  - Key elements: `falcon_pachinko.WebSocketResource`
+  - Purpose: handles connections and messages for a given route.
+  - Falcon analogy: Falcon HTTP `Resource`.
+
+- **Connection Lifecycle**
+
+  - Key elements: `on_connect()`, `on_disconnect()`
+  - Purpose: setup and teardown hooks for each connection.
+  - Falcon analogy: request/response middleware.
+
+- **Message Handling (Typed)**
+
+  - Key elements: `@handles_message()` and `on_{type}`
+  - Purpose: routes incoming JSON messages by type.
+  - Falcon analogy: `on_get`, `on_post`, etc.
+
+- **Message Handling (Generic)**
+
+  - Key elements: `on_unhandled()`
+  - Purpose: fallback for unrecognized or non-JSON messages.
+  - Falcon analogy: N/A.
+
+- **Background Worker Integration**
+
+  - Key elements: `WorkerController`, `@app.lifespan`
+  - Purpose: manages long-running tasks within the ASGI lifecycle.
+  - Falcon analogy: custom patterns.
+
+- **Connection Management (Global)**
+
+  - Key elements: `app.ws_connection_manager`
+  - Purpose: tracks connections and enables broadcasting.
+  - Falcon analogy: N/A.
 
 ## 4. Illustrative Usecase: Real-time Chat Application
 
@@ -667,7 +710,12 @@ import falcon.asgi
 from falcon_pachinko import WebSocketLike, WebSocketResource, handles_message
 
 class ChatRoomResource(WebSocketResource):
-    async def on_connect(self, req: falcon.Request, ws: WebSocketLike, room_name: str) -> bool:
+    async def on_connect(
+        self,
+        req: falcon.Request,
+        ws: WebSocketLike,
+        room_name: str,
+    ) -> bool:
         # Assume authentication middleware has set req.context.user
         self.user = req.context.get("user")
         if not self.user:
@@ -695,14 +743,26 @@ class ChatRoomResource(WebSocketResource):
         # Add validation/sanitization as needed
         await self.broadcast_to_room(
             self.room_name,
-            {"type": "serverNewMessage", "payload": {"user": self.user.name, "text": message_text}}
+            {
+                "type": "serverNewMessage",
+                "payload": {
+                    "user": self.user.name,
+                    "text": message_text,
+                },
+            }
         )
 
     @handles_message("clientStartTyping")
     async def handle_start_typing(self, ws: WebSocketLike, payload: dict):
         await self.broadcast_to_room(
             self.room_name,
-            {"type": "serverUserTyping", "payload": {"user": self.user.name, "isTyping": True}},
+            {
+                "type": "serverUserTyping",
+                "payload": {
+                    "user": self.user.name,
+                    "isTyping": True,
+                },
+            },
             exclude_self=True
         )
 
@@ -710,7 +770,13 @@ class ChatRoomResource(WebSocketResource):
     async def handle_stop_typing(self, ws: WebSocketLike, payload: dict):
         await self.broadcast_to_room(
             self.room_name,
-            {"type": "serverUserTyping", "payload": {"user": self.user.name, "isTyping": False}},
+            {
+                "type": "serverUserTyping",
+                "payload": {
+                    "user": self.user.name,
+                    "isTyping": False,
+                },
+            },
             exclude_self=True
         )
 
@@ -729,7 +795,10 @@ class ChatRoomResource(WebSocketResource):
 
     async def on_unhandled(self, ws: WebSocketLike, message: Union[str, bytes]):
         # Fallback for messages not matching handled types or non-JSON
-        print(f"Received unhandled message from {self.user.name} in {self.room_name}: {message}")
+        print(
+            "Received unhandled message from "
+            f"{self.user.name} in {self.room_name}: {message}"
+        )
         await ws.send_media({
             "type": "serverError",
             "payload": {"error": "Unrecognized message format or type."}
@@ -762,7 +831,9 @@ conn_mgr = app.ws_connection_manager
 app.add_websocket_route('/ws/chat/{room_name}', ChatRoomResource)
 
 # Define a background worker
-async def system_announcement_worker(conn_mgr: falcon_pachinko.WebSocketConnectionManager) -> None:
+async def system_announcement_worker(
+    conn_mgr: falcon_pachinko.WebSocketConnectionManager,
+) -> None:
     while True:
         await asyncio.sleep(3600) # Every hour
         announcement_text = "System maintenance is scheduled for 2 AM UTC."
@@ -1068,7 +1139,7 @@ sequenceDiagram
     Client->>FalconRequest: Initiates WebSocket request
     FalconRequest->>WebSocketRouter: on_websocket(req, ws)
     WebSocketRouter->>WebSocketRouter: Check req.path_template == _mount_prefix
-    WebSocketRouter->>WebSocketRouter: Match full request path against compiled routes
+    WebSocketRouter->>WebSocketRouter: Match path against compiled routes
     alt Match found
         WebSocketRouter->>ResourceFactory: Instantiate resource
         ResourceFactory-->>WebSocketRouter: Resource instance

--- a/docs/guide-to-modern-python-code-coverage.md
+++ b/docs/guide-to-modern-python-code-coverage.md
@@ -115,7 +115,12 @@ libraries), use:
 **Example:**
 
 ```bash
-slipcover --source=./my_app_src --omit="*/tests/*,*/venv/*" --branch --out coverage.xml -m pytest tests/
+slipcover \
+  --source=./my_app_src \
+  --omit="*/tests/*,*/venv/*" \
+  --branch \
+  --out coverage.xml \
+  -m pytest tests/
 ```
 
 ## 3. Test Execution with Pytest and Parallelization
@@ -135,7 +140,12 @@ For example, to generate a Cobertura XML report with branch coverage for tests
 in the `tests` directory, focusing on source code in `my_app_src`:
 
 ```bash
-python -m slipcover --source=./my_app_src --omit="*/tests/*,*/venv/*" --branch --out coverage.xml -m pytest -v tests/
+python -m slipcover \
+  --source=./my_app_src \
+  --omit="*/tests/*,*/venv/*" \
+  --branch \
+  --out coverage.xml \
+  -m pytest -v tests/
 ```
 
 ### 3.2. Leveraging `pytest-forked` for Test Isolation
@@ -269,7 +279,10 @@ data.
 
 ```yaml
 - name: Install CodeScene Coverage CLI
-  run: curl https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
+  run: >
+    curl
+    https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
+    | bash -s -- -y
 ```
 
 - Command Structure and Options:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,11 +5,13 @@ extension based on the revised, composable architecture detailed in the main
 design document. It supersedes the previous roadmap and reflects a pivot
 towards a more robust, scalable, and Falcon-idiomatic system.
 
-## Phase 1: Foundational Composable Router
+## 1. Foundational Composable Router
 
 This phase replaces the initial `app.add_websocket_route` mechanism with the
 more powerful and modular `WebSocketRouter`. This is the most significant
 architectural change and underpins all subsequent features.
+
+### 1.1. Composable router tasks
 
 - [x] **Deprecate the old routing API.**
 
@@ -50,10 +52,12 @@ architectural change and underpins all subsequent features.
     instantiate the associated resource with the correct path parameters and
     initialization arguments.
 
-## Phase 2: Advanced Dispatch and Resource Model
+## 2. Advanced Dispatch and Resource Model
 
 This phase refines the `WebSocketResource` to support the new schema-driven and
 composable patterns.
+
+### 2.1. Dispatch and resource model tasks
 
 - [ ] **Integrate** `msgspec` **for Schema-Driven Dispatch.**
 
@@ -115,10 +119,12 @@ composable patterns.
 
 [¹](falcon-websocket-extension-design.md#523-context-passing-for-nested-resources)
 
-## Phase 3: Lifespan Workers and Connection Management
+## 3. Lifespan Workers and Connection Management
 
 This phase implements the redesigned, ASGI-native background worker system and
 finalizes the connection manager API.
+
+### 3.1. Worker and connection management tasks
 
 - [x] **Implement Lifespan-Based Worker Management.**
 
@@ -147,10 +153,12 @@ finalizes the connection manager API.
   - [x] Ensure the default `InProcessBackend` correctly implements this new,
     robust interface.
 
-## Phase 4: Cross-Cutting Concerns
+## 4. Cross-Cutting Concerns
 
 This phase adds the essential features for building production-grade
 applications.
+
+### 4.1. Cross-cutting concern tasks
 
 - [x] **Implement the Multi-Tiered Hook System.**
 
@@ -182,10 +190,12 @@ applications.
   - [x] Document usage patterns (including test-oriented factories) and update
     examples to demonstrate DI wiring.
 
-## Phase 5: Testing, Documentation, and Examples
+## 5. Testing, Documentation, and Examples
 
 This is an ongoing process, but it will be finalized in this phase to ensure
 the library is ready for use.
+
+### 5.1. Testing, documentation, and example tasks
 
 - [x] **Develop Comprehensive Testing Utilities.**
 

--- a/falcon_pachinko/_testing_harness.py
+++ b/falcon_pachinko/_testing_harness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses as dc
+import types
 import typing as typ
 from types import SimpleNamespace
 
@@ -58,7 +59,7 @@ if typ.TYPE_CHECKING:
 try:  # pragma: no cover - optional dependency for fixture registration
     import pytest
 except ImportError:  # pragma: no cover - fixture only available under pytest
-    pytest = None  # type: ignore[assignment]
+    pytest: types.ModuleType | None = None
 else:
 
     @pytest.fixture

--- a/falcon_pachinko/behaviour/test_nested_resource.py
+++ b/falcon_pachinko/behaviour/test_nested_resource.py
@@ -200,7 +200,7 @@ def _simulate_connection(
     """Simulate a WebSocket connection."""
     router: WebSocketRouter = context["router"]
     ws = DummyWS()
-    req = typ.cast("falcon.Request", SimpleNamespace(path=path, path_template=""))
+    req = SimpleNamespace(path=path, path_template="")
     if capture_exceptions:
         try:
             asyncio.run(router.on_websocket(req, ws))

--- a/falcon_pachinko/handlers.py
+++ b/falcon_pachinko/handlers.py
@@ -132,7 +132,6 @@ def handles_message(
     def decorator(
         func: cabc.Callable[..., cabc.Awaitable[None]],
     ) -> _HandlesMessageDescriptor:
-        typed = typ.cast("Handler", func)
-        return _HandlesMessageDescriptor(message_type, typed, strict=strict)
+        return _HandlesMessageDescriptor(message_type, func, strict=strict)
 
     return decorator

--- a/falcon_pachinko/hooks.py
+++ b/falcon_pachinko/hooks.py
@@ -177,7 +177,7 @@ class HookManager:
         for hook in hooks:
             result = hook(context)
             if inspect.isawaitable(result):
-                await typ.cast("typ.Awaitable[None]", result)
+                await result
         return
 
     async def _run_hooks(

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -39,12 +39,26 @@ SimulatorFactory = typ.Callable[
 ]
 
 
-def _request_path(req: object) -> str:
+class _RequestLike(typ.Protocol):
+    """Request surface consumed by the router before resource dispatch."""
+
+    @property
+    def path(self) -> str:
+        """Return the request path."""
+        ...
+
+    @property
+    def path_template(self) -> str:
+        """Return the mount path template."""
+        ...
+
+
+def _request_path(req: _RequestLike) -> str:
     """Return the request path used for route matching."""
-    return typ.cast("str", typ.cast("typ.Any", req).path)
+    return req.path
 
 
-def _request_path_template(req: object) -> str:
+def _request_path_template(req: _RequestLike) -> str:
     """Return the mounted path template, defaulting like Falcon does."""
     return typ.cast("str", getattr(req, "path_template", ""))
 
@@ -228,7 +242,7 @@ class WebSocketRouter:
         return _normalize_path(template.format(**params))
 
     async def on_websocket(
-        self, req: object, ws: WebSocketLike
+        self, req: _RequestLike, ws: WebSocketLike
     ) -> None:  # pragma: no cover - simple wrapper
         """Dispatch the connection to the first matching route.
 
@@ -254,7 +268,7 @@ class WebSocketRouter:
         raise falcon.HTTPNotFound
 
     async def _try_route(
-        self, route: _CompiledRoute, req: object, ws: WebSocketLike
+        self, route: _CompiledRoute, req: _RequestLike, ws: WebSocketLike
     ) -> bool:
         """Attempt to handle ``req`` using ``route``.
 
@@ -285,7 +299,7 @@ class WebSocketRouter:
     async def _execute_route_with_error_handling(
         self,
         route: _CompiledRoute,
-        req: object,
+        req: _RequestLike,
         ws: WebSocketLike,
         params: dict[str, str],
         remaining: str,
@@ -304,7 +318,9 @@ class WebSocketRouter:
                     await ws_for_cleanup.close()
             raise
 
-    async def _prepare_websocket(self, req: object, ws: WebSocketLike) -> WebSocketLike:
+    async def _prepare_websocket(
+        self, req: _RequestLike, ws: WebSocketLike
+    ) -> WebSocketLike:
         """Return the WebSocket to use for ``req``."""
         # When :attr:`_simulator_factory` is configured the factory may wrap or
         # replace ``ws`` with an injectable simulator. The returned object is
@@ -337,7 +353,7 @@ class WebSocketRouter:
     async def _process_route_resolution(
         self,
         route: _CompiledRoute,
-        req: object,
+        req: _RequestLike,
         ws: WebSocketLike,
         params: dict[str, str],
         remaining: str,
@@ -363,7 +379,7 @@ class WebSocketRouter:
         resource: WebSocketResource,
         base_resource: WebSocketResource,
         route: _CompiledRoute,
-        req: object,
+        req: _RequestLike,
     ) -> bool:
         """Return ``True`` if ``resource`` is usable for ``req``."""
         return not (
@@ -430,7 +446,7 @@ class WebSocketRouter:
         return resource, path, params
 
     def _validate_and_normalize_path(
-        self, route: _CompiledRoute, req: object
+        self, route: _CompiledRoute, req: _RequestLike
     ) -> tuple[dict[str, str], str] | None:
         """Return params and remaining path or ``None`` if invalid."""
         if not (match := route.prefix.match(_request_path(req))):
@@ -473,7 +489,7 @@ class WebSocketRouter:
     async def _handle_websocket_connection(
         self,
         resource: WebSocketResource,
-        req: object,
+        req: _RequestLike,
         ws: WebSocketLike,
         params: dict[str, str],
         *,
@@ -498,7 +514,7 @@ class WebSocketRouter:
         self,
         hook_manager: HookManager,
         resource: WebSocketResource,
-        req: object,
+        req: _RequestLike,
         ws: WebSocketLike,
         params: dict[str, str],
     ) -> tuple[HookContext, dict[str, object]]:
@@ -515,7 +531,7 @@ class WebSocketRouter:
     async def _execute_resource_handler(
         self,
         resource: WebSocketResource,
-        req: object,
+        req: _RequestLike,
         ws: WebSocketLike,
         params: dict[str, object],
         context: HookContext,

--- a/falcon_pachinko/router.py
+++ b/falcon_pachinko/router.py
@@ -39,6 +39,16 @@ SimulatorFactory = typ.Callable[
 ]
 
 
+def _request_path(req: object) -> str:
+    """Return the request path used for route matching."""
+    return typ.cast("str", typ.cast("typ.Any", req).path)
+
+
+def _request_path_template(req: object) -> str:
+    """Return the mounted path template, defaulting like Falcon does."""
+    return typ.cast("str", getattr(req, "path_template", ""))
+
+
 def _replace_param_in_template(match: re.Match[str], template: str) -> str:
     """Return a regex group for ``match`` ensuring the param is non-empty."""
     param_name = match.group(1)
@@ -218,7 +228,7 @@ class WebSocketRouter:
         return _normalize_path(template.format(**params))
 
     async def on_websocket(
-        self, req: falcon.Request, ws: WebSocketLike
+        self, req: object, ws: WebSocketLike
     ) -> None:  # pragma: no cover - simple wrapper
         """Dispatch the connection to the first matching route.
 
@@ -227,7 +237,7 @@ class WebSocketRouter:
         the requested path does not map to this router's mount point.
         """
         # Handle missing or empty path_template by defaulting to root "/"
-        prefix = getattr(req, "path_template", "").rstrip("/") or "/"
+        prefix = _request_path_template(req).rstrip("/") or "/"
         if prefix != self._mount_prefix:
             msg = (
                 f"path_template '{prefix}' does not match router mount "
@@ -244,7 +254,7 @@ class WebSocketRouter:
         raise falcon.HTTPNotFound
 
     async def _try_route(
-        self, route: _CompiledRoute, req: falcon.Request, ws: WebSocketLike
+        self, route: _CompiledRoute, req: object, ws: WebSocketLike
     ) -> bool:
         """Attempt to handle ``req`` using ``route``.
 
@@ -275,7 +285,7 @@ class WebSocketRouter:
     async def _execute_route_with_error_handling(
         self,
         route: _CompiledRoute,
-        req: falcon.Request,
+        req: object,
         ws: WebSocketLike,
         params: dict[str, str],
         remaining: str,
@@ -294,9 +304,7 @@ class WebSocketRouter:
                     await ws_for_cleanup.close()
             raise
 
-    async def _prepare_websocket(
-        self, req: falcon.Request, ws: WebSocketLike
-    ) -> WebSocketLike:
+    async def _prepare_websocket(self, req: object, ws: WebSocketLike) -> WebSocketLike:
         """Return the WebSocket to use for ``req``."""
         # When :attr:`_simulator_factory` is configured the factory may wrap or
         # replace ``ws`` with an injectable simulator. The returned object is
@@ -305,7 +313,7 @@ class WebSocketRouter:
         if self._simulator_factory is None:
             return ws
 
-        candidate = self._simulator_factory(req, ws)
+        candidate = self._simulator_factory(typ.cast("falcon.Request", req), ws)
         if inspect.isawaitable(candidate):
             candidate = await candidate
 
@@ -329,7 +337,7 @@ class WebSocketRouter:
     async def _process_route_resolution(
         self,
         route: _CompiledRoute,
-        req: falcon.Request,
+        req: object,
         ws: WebSocketLike,
         params: dict[str, str],
         remaining: str,
@@ -355,10 +363,13 @@ class WebSocketRouter:
         resource: WebSocketResource,
         base_resource: WebSocketResource,
         route: _CompiledRoute,
-        req: falcon.Request,
+        req: object,
     ) -> bool:
         """Return ``True`` if ``resource`` is usable for ``req``."""
-        return not (resource is base_resource and not route.pattern.fullmatch(req.path))
+        return not (
+            resource is base_resource
+            and not route.pattern.fullmatch(_request_path(req))
+        )
 
     def _setup_hook_management(self, chain: list[WebSocketResource]) -> HookManager:
         """Attach a :class:`HookManager` to every resource in ``chain``."""
@@ -419,13 +430,13 @@ class WebSocketRouter:
         return resource, path, params
 
     def _validate_and_normalize_path(
-        self, route: _CompiledRoute, req: falcon.Request
+        self, route: _CompiledRoute, req: object
     ) -> tuple[dict[str, str], str] | None:
         """Return params and remaining path or ``None`` if invalid."""
-        if not (match := route.prefix.match(req.path)):
+        if not (match := route.prefix.match(_request_path(req))):
             return None
         params = match.groupdict()
-        remaining = req.path[match.end() :]
+        remaining = _request_path(req)[match.end() :]
         if remaining and not remaining.startswith("/"):
             remaining = self._normalize_path_remaining(remaining, match)
             if remaining is None:
@@ -456,13 +467,13 @@ class WebSocketRouter:
             return self._resource_factory(route_factory)
         except Exception as exc:  # pragma: no cover - exercise via tests
             await ws.close()
-            exc._pachinko_factory_closed = True  # type: ignore[attr-defined]
+            typ.cast("typ.Any", exc)._pachinko_factory_closed = True
             raise
 
     async def _handle_websocket_connection(
         self,
         resource: WebSocketResource,
-        req: falcon.Request,
+        req: object,
         ws: WebSocketLike,
         params: dict[str, str],
         *,
@@ -487,14 +498,14 @@ class WebSocketRouter:
         self,
         hook_manager: HookManager,
         resource: WebSocketResource,
-        req: falcon.Request,
+        req: object,
         ws: WebSocketLike,
         params: dict[str, str],
     ) -> tuple[HookContext, dict[str, object]]:
         """Return the hook context and handler parameters."""
         params_obj: dict[str, object] = dict(params)
         context = await hook_manager.notify_before_connect(
-            resource, req=req, ws=ws, params=params_obj
+            resource, req=typ.cast("falcon.Request", req), ws=ws, params=params_obj
         )
         params_for_handler = (
             context.params if context.params is not None else params_obj
@@ -504,7 +515,7 @@ class WebSocketRouter:
     async def _execute_resource_handler(
         self,
         resource: WebSocketResource,
-        req: falcon.Request,
+        req: object,
         ws: WebSocketLike,
         params: dict[str, object],
         context: HookContext,
@@ -512,7 +523,9 @@ class WebSocketRouter:
     ) -> bool:
         """Invoke ``resource.on_connect`` handling hook error propagation."""
         try:
-            return await resource.on_connect(req, ws, **params)
+            return await resource.on_connect(
+                typ.cast("falcon.Request", req), ws, **params
+            )
         except Exception as exc:
             context.error = exc
             context.result = False

--- a/falcon_pachinko/testing/client.py
+++ b/falcon_pachinko/testing/client.py
@@ -24,10 +24,14 @@ from ._common import (
     PayloadKind,
 )
 
+_ws_connect: typ.Any
+
 try:  # pragma: no cover - optional dependency exercised in tests
-    from websockets.client import connect as _ws_connect
+    from websockets.client import connect as _ws_connect_import
 except ImportError:  # pragma: no cover - imported lazily in tests
-    _ws_connect = None  # type: ignore[assignment]
+    _ws_connect = None
+else:
+    _ws_connect = _ws_connect_import
 
 if typ.TYPE_CHECKING:  # pragma: no cover - typing only
     from websockets.client import WebSocketClientProtocol
@@ -375,7 +379,7 @@ class WebSocketTestClient:
         ws_connect = _ws_connect
         if ws_connect is None:  # pragma: no cover - exercised via import error test
             try:
-                from websockets.client import connect as ws_connect  # type: ignore
+                from websockets.client import connect as ws_connect
             except ImportError as exc:  # pragma: no cover - optional dependency
                 raise MissingDependencyError(_MISSING_WEBSOCKETS_MSG) from exc
             _ws_connect = ws_connect

--- a/falcon_pachinko/testing/harness.py
+++ b/falcon_pachinko/testing/harness.py
@@ -173,10 +173,7 @@ class SimulatorRouterHarness:
         request = _TestRequest(path=request_path, path_template=self._mount_prefix)
         original = _OriginalWebSocket()
         try:
-            await self.router.on_websocket(
-                typ.cast("falcon.asgi.Request", request),
-                original,
-            )
+            await self.router.on_websocket(request, original)
             yield SimulatorConnection(
                 path=request_path,
                 router=self.router,

--- a/falcon_pachinko/unittests/test_app_install.py
+++ b/falcon_pachinko/unittests/test_app_install.py
@@ -216,7 +216,7 @@ def test_add_websocket_route_invalid_path(
     results in a ValueError.
     """
     with pytest.raises(ValueError, match="Invalid WebSocket route path"):
-        dummy_app.add_websocket_route(path, dummy_resource_cls)  # type: ignore[arg-type]
+        dummy_app.add_websocket_route(typ.cast("str", path), dummy_resource_cls)
 
 
 def test_create_websocket_resource_returns_new_instances(

--- a/falcon_pachinko/unittests/test_nested_resources.py
+++ b/falcon_pachinko/unittests/test_nested_resources.py
@@ -45,10 +45,7 @@ async def test_nested_subroute_params() -> None:
     router = WebSocketRouter()
     router.add_route("/parent/{pid}", Parent)
     router.mount("/")
-    req = typ.cast(
-        "falcon.Request",
-        SimpleNamespace(path="/parent/1/child/2", path_template=""),
-    )
+    req = SimpleNamespace(path="/parent/1/child/2", path_template="")
     await router.on_websocket(req, DummyWS())
 
     assert Child.instances[-1].params == {"pid": "1", "cid": "2"}
@@ -68,10 +65,7 @@ async def test_nested_subroute_not_found(path: str, description: str) -> None:
     router = WebSocketRouter()
     router.add_route("/parent/{pid}", Parent)
     router.mount("/")
-    req = typ.cast(
-        "falcon.Request",
-        SimpleNamespace(path=path, path_template=""),
-    )
+    req = SimpleNamespace(path=path, path_template="")
     with pytest.raises(falcon.HTTPNotFound):
         await router.on_websocket(req, DummyWS())
 
@@ -132,10 +126,7 @@ async def _setup_and_run_nested_test(
     router = WebSocketRouter()
     router.add_route(route_path, parent_class)
     router.mount("/")
-    req = typ.cast(
-        "falcon.Request",
-        SimpleNamespace(path=request_path, path_template=""),
-    )
+    req = SimpleNamespace(path=request_path, path_template="")
     await router.on_websocket(req, DummyWS())
     parent = parent_class.instances[-1]
     child = child_class.instances[-1]

--- a/falcon_pachinko/unittests/test_router.py
+++ b/falcon_pachinko/unittests/test_router.py
@@ -187,7 +187,7 @@ async def test_not_found_raises() -> None:
     router = WebSocketRouter()
     router.add_route("/ok", DummyResource)
     router.mount("/")
-    req = type("Req", (), {"path": "/missing"})()
+    req = type("Req", (), {"path": "/missing", "path_template": ""})()
 
     with pytest.raises(falcon.HTTPNotFound):
         await router.on_websocket(req, DummyWS())
@@ -218,7 +218,7 @@ async def test_on_connect_accepts_connection() -> None:
         called["accepted"] = True
 
     typ.cast("typ.Any", ws).accept = accept
-    req = type("Req", (), {"path": "/ok"})()
+    req = type("Req", (), {"path": "/ok", "path_template": ""})()
     await router.on_websocket(req, ws)
     assert called.get("accepted") is True
 

--- a/falcon_pachinko/unittests/test_websocket_resource.py
+++ b/falcon_pachinko/unittests/test_websocket_resource.py
@@ -392,7 +392,7 @@ async def test_state_rejects_non_mapping() -> None:
     """Assigning non-mapping to ``state`` raises ``TypeError``."""
     r = EchoResource()
     with pytest.raises(TypeError):
-        r.state = 123  # type: ignore[arg-type]
+        typ.cast("typ.Any", r).state = 123
 
 
 @pytest.mark.asyncio

--- a/falcon_pachinko/workers.py
+++ b/falcon_pachinko/workers.py
@@ -31,7 +31,7 @@ class WorkerController:
         await self._stack.__aenter__()
 
         for fn in workers:
-            coroutine = typ.cast("cabc.Coroutine[object, object, None]", fn(**context))
+            coroutine = fn(**context)
             task = asyncio.create_task(coroutine)
             self._tasks.append(task)
 
@@ -73,5 +73,5 @@ class WorkerController:
 
 def worker(fn: WorkerFn) -> WorkerFn:
     """Mark *fn* as a background worker."""
-    fn.__pachinko_worker__ = True  # type: ignore[attr-defined]
+    typ.cast("typ.Any", fn).__pachinko_worker__ = True
     return fn

--- a/tests/behaviour/test_reference_example_steps.py
+++ b/tests/behaviour/test_reference_example_steps.py
@@ -138,10 +138,7 @@ def when_send_task_add(
     payload = AddTask(task_id="T-42", title="Investigate event loop")
     raw = msjson.encode(payload)
     event_loop.run_until_complete(resource.dispatch(context.simulator, raw))
-    context.last_event = typ.cast(
-        "tuple[str, dict[str, object]]",
-        event_loop.run_until_complete(context.feed.next_event()),
-    )
+    context.last_event = event_loop.run_until_complete(context.feed.next_event())
     return context
 
 

--- a/tests/behaviour/test_reference_example_steps.py
+++ b/tests/behaviour/test_reference_example_steps.py
@@ -122,9 +122,7 @@ def when_client_connects(
         path="/ws/workspaces/atlas/projects/triage/tasks",
         headers={"x-workspace-token": "seekrit", "x-user": "casey"},
     )
-    event_loop.run_until_complete(
-        context.router.on_websocket(typ.cast("falcon.Request", req), context.simulator)
-    )
+    event_loop.run_until_complete(context.router.on_websocket(req, context.simulator))
     context.resource = _select_task_resource(context.instances)
     return context
 

--- a/tests/behaviour/test_websocket_test_client_steps.py
+++ b/tests/behaviour/test_websocket_test_client_steps.py
@@ -70,7 +70,7 @@ def echo_service(event_loop: asyncio.AbstractEventLoop) -> typ.Iterator[ClientCo
     server = event_loop.run_until_complete(
         ws_server.serve(handler, "127.0.0.1", 0, subprotocols=protocols)
     )
-    host, port, *_ = server.sockets[0].getsockname()
+    host, port, *_ = next(iter(server.sockets)).getsockname()
     base_url = f"ws://{host}:{port}"
     client = WebSocketTestClient(
         base_url,

--- a/tests/test_reference_example_unit.py
+++ b/tests/test_reference_example_unit.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import typing as typ
 
-import falcon
 import pytest
 from falcon import HTTPUnauthorized
 
@@ -72,10 +71,7 @@ async def test_router_rejects_missing_token() -> None:
     req = _RequestStub(headers={})
     ws = _WebSocketStub()
     with pytest.raises(HTTPUnauthorized):
-        await router.on_websocket(
-            typ.cast("falcon.Request", req),
-            ws,
-        )
+        await router.on_websocket(req, ws)
     assert ws.closed is True
     assert ws.accepted is False
 
@@ -86,7 +82,7 @@ async def test_router_accepts_with_valid_token() -> None:
     router, _ = _build_router()
     req = _RequestStub(headers={"x-workspace-token": "seekrit", "x-user": "riley"})
     ws = _WebSocketStub()
-    await router.on_websocket(typ.cast("falcon.Request", req), ws)
+    await router.on_websocket(req, ws)
     assert ws.accepted is True
     assert ws.messages
     first = typ.cast("dict[str, object]", ws.messages[0])


### PR DESCRIPTION
## Summary

This branch aligns [docs/roadmap.md](https://github.com/leynos/falcon-pachinko/blob/docs/roadmap-syntax/docs/roadmap.md) with the mapsplice roadmap grammar. The five phase headings used the `## Phase N: Title` style, which the grammar checker rejects ("roadmap must contain at least one numbered phase"); they are now `## N. Title`, with the title wording unchanged. Because the grammar also forbids task checklists sitting directly under a phase, each phase's task list now sits under a new numbered step heading (`### N.1. ...`) derived from the phase title. No tasks were reordered, renumbered, reworded, or had their checkbox states changed.

Review feedback also removes the malformed `.coderabbit.yaml`, updates `make build` to recreate the existing virtual environment with `uv venv --clear`, and fixes the `ty` diagnostics exposed once the CI typecheck gate can reach analysis.

## Review walkthrough

- Start with [docs/roadmap.md](https://github.com/leynos/falcon-pachinko/blob/docs/roadmap-syntax/docs/roadmap.md) to see the renumbered phase headings and the five inserted step headings (1.1, 2.1, 3.1, 4.1, and 5.1); everything else in the document is untouched.
- [docs/roadmap-v1-legacy.md](https://github.com/leynos/falcon-pachinko/blob/docs/roadmap-syntax/docs/roadmap-v1-legacy.md) is deliberately unchanged; it is the archived roadmap that docs/roadmap.md explicitly supersedes.
- [Makefile](https://github.com/leynos/falcon-pachinko/blob/docs/roadmap-syntax/Makefile) now mirrors the virtualenv rebuild approach used by falcon-correlate.

## Validation

- `mapsplice append docs/roadmap.md <dummy-phase>`: exit 0 (grammar-clean)
- `mbake validate Makefile`: exit 0
- `make check-fmt`: exit 0
- `make lint`: exit 0
- `make typecheck`: exit 0
- `make test`: exit 0 (159 passed)

## Notes

- The inserted step titles (for example "Composable router tasks") are concise derivations of their phase titles, as each phase held a single undivided task list.
- The existing unnumbered, bold-titled tasks are accepted by the checker at step level and were left unnumbered, per the minimal-change scope.
- [docs/roadmap-v1-legacy.md](https://github.com/leynos/falcon-pachinko/blob/docs/roadmap-syntax/docs/roadmap-v1-legacy.md) is an archived, superseded document and was left outwith the audit.

## References

- Lody session: https://lody.ai/leynos/sessions/b81ae843-42cc-475b-89a6-5e6a9d97a5c7