### PR TITLE
Wire CodeScene coverage upload and ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Full history so a future `cs-coverage check` can reach the
+          # pull request's merge base (see the deferred gate note below).
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -43,38 +47,30 @@ jobs:
       - name: Run typechecker
         run: make typecheck
 
-      - name: Run tests with coverage
-        run: |
-          uv pip install slipcover pytest-forked
-          uv run python -m slipcover \
-            --source=./falcon_pachinko \
-            --omit="*/unittests/*,*/.venv/*" \
-            --branch \
-            --out coverage.xml \
-            -m pytest --forked -v falcon_pachinko/unittests
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+      # Coverage runs on pull requests only. Pushes to main upload their
+      # own coverage (and advance the ratchet baseline) via
+      # coverage-main.yml, so generating it here as well would duplicate
+      # the work and the CodeScene upload for the same commit.
+      - name: Generate coverage
+        if: github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
-          name: coverage
-          path: coverage.xml
-
-      - name: Install CodeScene Coverage CLI
-        if: env.CS_ACCESS_TOKEN != ''
-        run: |
-          curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
-          if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
-            echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c -
-          fi
-
-      - name: Upload coverage to CodeScene
-        if: env.CS_ACCESS_TOKEN != ''
-        run: |
-          if [ ! -f coverage.xml ]; then
-            echo "coverage.xml not found!"
-            exit 1
-          fi
-          cs-coverage upload \
-            --format "cobertura" \
-            --metric "line-coverage" \
-            coverage.xml
+          output-path: coverage.xml
+          format: cobertura
+          # The suite previously ran under slipcover with pytest-forked and
+          # no xdist; keep it serial to stay behaviour-preserving. Follow-up
+          # 4 removes this pin to adopt pytest-xdist once the suite is
+          # confirmed xdist-clean. Note: serial mode is in-process, so the
+          # fork isolation the old `--forked` run provided is dropped.
+          pytest-workers: ''
+          with-ratchet: 'true'
+      # The `mode: check` step is deliberately not wired in yet: CodeScene
+      # project 68790 has no coverage-gates configuration, so
+      # `cs-coverage check` fails every run with "HTTP call succeeded,
+      # but the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (ddlint, chutoro, and cmd-mox's projects hit the
+      # byte-identical error). Add the check step in a fast-follow PR once
+      # coverage-main.yml has uploaded to main at least once and the gate
+      # is confirmed to resolve, or once CodeScene confirms the project's
+      # coverage gate is enabled.

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,52 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests run the
+# coverage generation (and, in a future fast-follow, the changed-line
+# `cs-coverage check` gate) in ci.yml instead. This workflow also
+# advances the coverage ratchet baseline: caches saved on main are
+# readable by every pull-request run, so the baseline written here is
+# the one PR ratchet checks compare against.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: coverage.xml
+          format: cobertura
+          # Keep the run serial to match the pull-request coverage job;
+          # see the note in ci.yml.
+          pytest-workers: ''
+          with-ratchet: 'true'
+
+      - name: Upload coverage data to CodeScene
+        if: env.CS_ACCESS_TOKEN
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          path: coverage.xml
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1990e9a6aaa73f0929e04dbc7da12326005606bf
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Onboards falcon-pachinko to the shared CodeScene coverage tooling,
following the cmd-mox Python pathfinder (#190) and the estate rollout
recipe. CodeScene project id is **68790**.

- [`ci.yml`](https://github.com/leynos/falcon-pachinko/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  replaces the bespoke slipcover run and hand-rolled `cs-coverage upload`
  with the shared
  [`generate-coverage`](https://github.com/leynos/shared-actions/tree/927edd45ae77be4251a8a18ca9eb5613a2e32cbd/.github/actions/generate-coverage)
  action (cobertura → `coverage.xml`, serial pytest, ratchet on). The
  step is guarded to pull requests so coverage is not generated twice
  once `coverage-main.yml` exists, and the checkout gains `fetch-depth: 0`
  for a future `cs-coverage check`.
- [`coverage-main.yml`](https://github.com/leynos/falcon-pachinko/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  uploads coverage to CodeScene and advances the ratchet baseline on
  pushes to `main` (`mode: upload`, the default). Caches saved on `main`
  are readable by every PR, so this baseline is the one PR ratchet
  checks compare against.
- [`dependabot-automerge.yml`](https://github.com/leynos/falcon-pachinko/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml)
  bumps the repo-wide shared-actions pin to `927edd4` (the coverage
  actions need at least this commit).

The changed-line `mode: check` gate is deliberately **not** wired in
yet: project 68790 has no coverage-gates configuration, so
`cs-coverage check` fails every run with "the received project-config
isn't valid. Lacks the gates configuration" — a CodeScene-side
per-project setting, not a CI defect (ddlint, chutoro and cmd-mox hit
the byte-identical error). A fast-follow adds it once the gate resolves.

### Why the CodeScene check is not in the ruleset

The `lint-test` check is the only required status check. The CodeScene
"Code Coverage" check is enabled per CodeScene project and gates via the
status rollup, not the branch ruleset — reviewers should not expect to
find it there. falcon-pachinko's project currently posts only "Code
Health Review", so nothing is jammed today.

## Review walkthrough

- The generate-coverage step runs serially (`pytest-workers: ''`) to
  preserve the previous slipcover + `pytest-forked` behaviour; note that
  serial mode is in-process, so the fork isolation the old `--forked`
  run gave is dropped. Follow-up 4 removes the pin once the suite is
  confirmed xdist-clean.
- The shared action takes no slipcover `--source`/`--omit` scoping, so
  coverage now measures everything imported (including test modules)
  rather than only `falcon_pachinko/`, and it runs the full suite
  (`tests/` plus `falcon_pachinko/unittests/`, matching `make test`)
  rather than only `unittests`. The ratchet baseline lands at that
  broadened percentage.
- cobertura is kept (the Python leg rejects lcov), so `coverage.xml`
  stays the report path throughout.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` passes on all three
  workflows.
- No workflow-contract tests pin this repo's workflow text.
- CI on this PR head exercises the new `generate-coverage` step; the
  `coverage-main.yml` upload path is exercised on the first push to
  `main` after merge.

## Rollup / automerge mechanism

Dependabot automerge reads the whole status rollup. Once the secret is
set and this lands, Dependabot PRs must be rebased (`@dependabot rebase`)
to pick up the new workflows; old heads still carry the bespoke upload
step.
