### PR TITLE
Add CodeScene mode: check gate to the PR coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
-          # Full history so a future `cs-coverage check` can reach the
-          # pull request's merge base (see the deferred gate note below).
+          # Full history so `cs-coverage check` can reach the pull
+          # request's merge base.
           fetch-depth: 0
 
       - name: Set up Python
@@ -68,13 +68,15 @@ jobs:
           # fork isolation the old `--forked` run provided is dropped.
           pytest-workers: ''
           with-ratchet: 'true'
-      # The `mode: check` step is deliberately not wired in yet: CodeScene
-      # project 68790 has no coverage-gates configuration, so
-      # `cs-coverage check` fails every run with "HTTP call succeeded,
-      # but the received project-config isn't valid. Lacks the gates
-      # configuration." — a CodeScene-side per-project setting, not a CI
-      # defect (ddlint, chutoro, and cmd-mox's projects hit the
-      # byte-identical error). Add the check step in a fast-follow PR once
-      # coverage-main.yml has uploaded to main at least once and the gate
-      # is confirmed to resolve, or once CodeScene confirms the project's
-      # coverage gate is enabled.
+
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/68790
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary

- CodeScene project [68790](https://api.codescene.io/v2/projects/68790) now has its coverage-gates configuration enabled, so the deferred `cs-coverage check` step can succeed instead of failing with "Lacks the gates configuration".
- Replace the deferred-gate comment in [`ci.yml`](https://github.com/leynos/falcon-pachinko/blob/codescene-mode-check/.github/workflows/ci.yml) with the guarded gate step, evaluating changed-line coverage against the project's stored baseline on every pull request.

## Review walkthrough

- The new "Check coverage against CodeScene gates" step runs only when `CS_ACCESS_TOKEN` is set and the event is `pull_request` (guards forks and non-PR pushes, e.g. Dependabot pushing straight to a branch).
- It reuses the `upload-codescene-coverage` pin (`927edd4…`) already trusted by `coverage-main.yml`'s `mode: upload` step — no new Dependabot-tracked pin introduced.
- `project-url` uses the `/v2/projects/68790` form per the shared action's contract.
- The PR job already checks out with `fetch-depth: 0`, so the merge base is reachable for the changed-line diff.
- `coverage-main.yml` is untouched — it keeps `mode: upload` on push to `main`, feeding CodeScene's stored baseline; the PR job's `mode: check` step only evaluates against that baseline.
- No workflow-contract tests exist in this repository that pin `ci.yml`'s step shape, so none needed updating.

Note for reviewers: the `CodeScene Code Coverage` check this step drives is **not** a required status check in the branch ruleset — CodeScene enforces it via the whole status-check rollup, so it will not show up if you search the ruleset for a named required check.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses cleanly.
- `CS_ACCESS_TOKEN` is already set in both the Actions and Dependabot secret stores for this repository.
- Awaiting this PR's own CI run to confirm the "Check coverage against CodeScene gates" step executes (not skipped) and succeeds, and that the `CodeScene Code Coverage` check on the PR completes rather than timing out or erroring.
